### PR TITLE
Fix Animated.event type so it can be used in `Animated.ScrollView` `onScroll` props (& similar)

### DIFF
--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -262,7 +262,7 @@ external eventOptions2:
 type event('event) = 'event => unit;
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: ('mapping, eventOptions) => event('event) = "";
+external event: (array('mapping), eventOptions) => event('event) = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external event2: (('mapping, 'mapping2), eventOptions2) => event('event) = "";

--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -246,10 +246,10 @@ external loop: Animation.t => Animation.t = "";
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 
-type animatedEvent;
+type animatedEvent('a) = 'a => unit;
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: (array('a), 'b) => animatedEvent = "";
+external event: (array('a), 'b) => animatedEvent('c) = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:

--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -246,10 +246,26 @@ external loop: Animation.t => Animation.t = "";
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 
-type animatedEvent('a) = 'a => unit;
+type eventOptions;
+[@bs.obj]
+external eventOptions:
+  (~listener: 'event => unit=?, ~useNativeDriver: bool=?, unit) => eventOptions =
+  "";
+
+type eventOptions2;
+[@bs.obj]
+external eventOptions2:
+  (~listener: ('event, 'option2) => unit=?, ~useNativeDriver: bool=?, unit) =>
+  eventOptions2 =
+  "";
+
+type event('event) = 'event => unit;
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: (array('a), 'b) => animatedEvent('c) = "";
+external event: ('mapping, eventOptions) => event('event) = "";
+
+[@bs.module "react-native"] [@bs.scope "Animated"]
+external event2: (('mapping, 'mapping2), eventOptions2) => event('event) = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:

--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -262,10 +262,10 @@ external eventOptions2:
 type event('event) = 'event => unit;
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: (array('mapping), eventOptions) => event('event) = "";
+external event1: (array('mapping), eventOptions) => event('event) = "event";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event2: (('mapping, 'mapping2), eventOptions2) => event('event) = "";
+external event2: (('mapping, 'mapping2), eventOptions2) => event('event) = "event";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:

--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -246,26 +246,19 @@ external loop: Animation.t => Animation.t = "";
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 
-type eventOptions;
+type eventOptions('a);
 [@bs.obj]
 external eventOptions:
-  (~listener: 'event => unit=?, ~useNativeDriver: bool=?, unit) => eventOptions =
+  (~listener: 'a=?, ~useNativeDriver: bool=?, unit) => eventOptions('a) =
   "";
 
-type eventOptions2;
-[@bs.obj]
-external eventOptions2:
-  (~listener: ('event, 'option2) => unit=?, ~useNativeDriver: bool=?, unit) =>
-  eventOptions2 =
-  "";
-
-type event('event) = 'event => unit;
-
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event1: (array('mapping), eventOptions) => event('event) = "event";
+external event1: (array('mapping), eventOptions('a)) => 'a = "event";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event2: (('mapping, 'mapping2), eventOptions2) => event('event) = "event";
+external event2: (('mapping1, 'mapping2), eventOptions('a)) => 'a = "event";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -242,10 +242,19 @@ external loop: Animation.t => Animation.t = "";
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 
-type animatedEvent;
+type eventOptions('a);
+[@bs.obj]
+external eventOptions:
+  (~listener: 'a=?, ~useNativeDriver: bool=?, unit) => eventOptions('a) =
+  "";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: (array('a), 'b) => animatedEvent = "";
+external event1: (array('mapping), eventOptions('a)) => 'a = "event";
+
+// multiple externals
+[@bs.module "react-native"] [@bs.scope "Animated"]
+external event2: (('mapping1, 'mapping2), eventOptions('a)) => 'a = "event";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:


### PR DESCRIPTION
According to RN docs (and experience) it's handy to be able to use `Animated.event` to map `onScroll` event directly to an `Animated.Value`.
Currently the bindings make this impossible as if you try to do this

```reason
open ReactNative;

let styles = Style.(StyleSheet.create({"container": style(~flex=1., ())}));

type renderArgs = {
  scrollYAnimatedValue: Animated.Value.t,
  scrollViewRef:
    React.Ref.t(Js.Nullable.t(ReactNative.Animated.ScrollView.element)),
};

[@react.component]
let make =
    (
      ~style as s=?,
      ~contentContainerStyle=?,
      ~children: renderArgs => React.element,
    ) => {
  let scrollViewRef = React.useRef(Js.Nullable.null);
  let (scrollYAnimatedValue, _setScrollYAnimatedValue) =
    React.useState(() => Animated.Value.create(0.));

  <Animated.ScrollView
    ref=scrollViewRef
    style=Style.(arrayOption([|Some(styles##container), s|]))
    ?contentContainerStyle
    scrollEventThrottle=1
    onScroll={Animated.event(
      [|{
          "nativeEvent": {
            "contentOffset": {
              "y": scrollYAnimatedValue,
            },
          },
        }|],
      {"useNativeDriver": true},
    )}
    showsVerticalScrollIndicator=false
    showsHorizontalScrollIndicator=false>
    {children({scrollYAnimatedValue, scrollViewRef})}
  </Animated.ScrollView>;
};
```

You will get an error like this

```
  We've found a bug for you!
......./AnimatedScrollView.re 21:14-30:6

  19 ┆ ?contentContainerStyle
  20 ┆ scrollEventThrottle=1
  21 ┆ onScroll={Animated.event(
  22 ┆   [|{
   . ┆ ...
  29 ┆   {"useNativeDriver": true},
  30 ┆ )}
  31 ┆ showsVerticalScrollIndicator=false
  32 ┆ showsHorizontalScrollIndicator=false>

  This has type:
    ReactNative.Animated.animatedEvent (defined as
      ReactNative.Animated.animatedEvent)
  But somewhere wanted:
    ReactNative.Event.scrollEvent => unit
```

Which is valid!

This change make this valid (tested in the app I currently work on).