### PR TITLE
Fix Animated.Value.addListener parameter type

### DIFF
--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -12,7 +12,7 @@ module Animation = {
 module type Value = {
   type t;
   type jsValue;
-  type jsValueAddListener;
+  type addListenerCallback;
 };
 
 type calculated;
@@ -150,26 +150,22 @@ module ValueOperations = {
 module ValueMethods = (Val: Value) => {
   type t = Val.t;
   type jsValue = Val.jsValue;
-  type jsValueAddListener = Val.jsValueAddListener;
-
-  type callback('t) = 't => unit;
+  type addListenerCallback = Val.addListenerCallback;
+  type callback = jsValue => unit;
 
   [@bs.send] external setValue: (t, jsValue) => unit = "";
   [@bs.send] external setOffset: (t, jsValue) => unit = "";
   [@bs.send] external flattenOffset: t => unit = "";
   [@bs.send] external extractOffset: t => unit = "";
-  [@bs.send]
-  external addListener: (t, callback(jsValueAddListener)) => string = "";
+  [@bs.send] external addListener: (t, addListenerCallback) => string = "";
   [@bs.send] external removeListener: (t, string) => unit = "";
   [@bs.send] external removeAllListeners: t => unit = "";
 
   [@bs.send]
-  external resetAnimation: (t, ~callback: callback(jsValue)=?, unit) => unit =
-    "";
+  external resetAnimation: (t, ~callback: callback=?, unit) => unit = "";
 
   [@bs.send]
-  external stopAnimation: (t, ~callback: callback(jsValue)=?, unit) => unit =
-    "";
+  external stopAnimation: (t, ~callback: callback=?, unit) => unit = "";
 
   include ValueAnimations(Val);
 };
@@ -178,7 +174,7 @@ module Value = {
   include ValueMethods({
     type t = value(regular);
     type jsValue = float;
-    type jsValueAddListener = {. "value": jsValue};
+    type addListenerCallback = {. "value": jsValue} => unit;
   });
 
   [@bs.new] [@bs.scope "Animated"] [@bs.module "react-native"]
@@ -199,7 +195,7 @@ module ValueXY = {
       "x": float,
       "y": float,
     };
-    type jsValueAddListener = jsValue;
+    type addListenerCallback = jsValue => unit;
   });
 
   [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue = "";

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -178,7 +178,7 @@ module Value = {
   include ValueMethods({
     type t = value(regular);
     type jsValue = float;
-    type jsValueAddListener = {. "value": float};
+    type jsValueAddListener = {. "value": jsValue};
   });
 
   [@bs.new] [@bs.scope "Animated"] [@bs.module "react-native"]

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -12,6 +12,7 @@ module Animation = {
 module type Value = {
   type t;
   type jsValue;
+  type jsValueAddListener;
 };
 
 type calculated;
@@ -149,6 +150,7 @@ module ValueOperations = {
 module ValueMethods = (Val: Value) => {
   type t = Val.t;
   type jsValue = Val.jsValue;
+  type jsValueAddListener = Val.jsValueAddListener;
 
   type callback('t) = 't => unit;
 
@@ -157,7 +159,7 @@ module ValueMethods = (Val: Value) => {
   [@bs.send] external flattenOffset: t => unit = "";
   [@bs.send] external extractOffset: t => unit = "";
   [@bs.send]
-  external addListener: (t, callback({. "value": jsValue})) => string = "";
+  external addListener: (t, callback(jsValueAddListener)) => string = "";
   [@bs.send] external removeListener: (t, string) => unit = "";
   [@bs.send] external removeAllListeners: t => unit = "";
 
@@ -176,6 +178,7 @@ module Value = {
   include ValueMethods({
     type t = value(regular);
     type jsValue = float;
+    type jsValueAddListener = {. "value": float};
   });
 
   [@bs.new] [@bs.scope "Animated"] [@bs.module "react-native"]
@@ -196,6 +199,7 @@ module ValueXY = {
       "x": float,
       "y": float,
     };
+    type jsValueAddListener = jsValue;
   });
 
   [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue = "";

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -150,21 +150,24 @@ module ValueMethods = (Val: Value) => {
   type t = Val.t;
   type jsValue = Val.jsValue;
 
-  type callback = jsValue => unit;
+  type callback('t) = 't => unit;
 
   [@bs.send] external setValue: (t, jsValue) => unit = "";
   [@bs.send] external setOffset: (t, jsValue) => unit = "";
   [@bs.send] external flattenOffset: t => unit = "";
   [@bs.send] external extractOffset: t => unit = "";
-  [@bs.send] external addListener: (t, callback) => string = "";
+  [@bs.send]
+  external addListener: (t, callback({. "value": jsValue})) => string = "";
   [@bs.send] external removeListener: (t, string) => unit = "";
   [@bs.send] external removeAllListeners: t => unit = "";
 
   [@bs.send]
-  external resetAnimation: (t, ~callback: callback=?, unit) => unit = "";
+  external resetAnimation: (t, ~callback: callback(jsValue)=?, unit) => unit =
+    "";
 
   [@bs.send]
-  external stopAnimation: (t, ~callback: callback=?, unit) => unit = "";
+  external stopAnimation: (t, ~callback: callback(jsValue)=?, unit) => unit =
+    "";
 
   include ValueAnimations(Val);
 };


### PR DESCRIPTION
The callback for `Animated.Value.addListener` is currently typed like this: `float => unit`, but is supposed to be `{. "value": float} => unit`.

Link to RN docs: https://facebook.github.io/react-native/docs/animatedvalue#addlistener