### PR TITLE
fix(WebView): event types

### DIFF
--- a/src/components/WebView.md
+++ b/src/components/WebView.md
@@ -29,17 +29,52 @@ module Source = {
 module DataDetectorTypes = WebView_DataDetectorTypes;
 module DecelerationRate = WebView_DecelerationRate;
 
-type messageEvent = Event.syntheticEvent({. "data": string});
+class type webViewBaseEvent = {
+  pub url: string;
+  pub title: string;
+  pub loading: bool;
+  pub canGoBack: bool;
+  pub canGoForward: bool;
+  pub lockIdentifier: int;
+};
 
-type webViewEvent =
-  Event.syntheticEvent({
-    .
-    "url": string,
-    "title": string,
-    "loading": bool,
-    "canGoBack": bool,
-    "canGoForward": bool,
-  });
+class type virtual webViewNavigation = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub navigationType: string;
+  pub mainDocumentURL: option(string);
+};
+
+class type virtual webViewError = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub domain: option(string);
+  pub code: int;
+  pub description: string;
+};
+
+class type virtual webViewErrorOrNavigation = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub domain: option(string);
+  pub code: option(int);
+  pub description: string;
+  pub navigationType: string;
+  pub mainDocumentURL: option(string);
+};
+
+class type virtual webViewMessage = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub data: string;
+};
+
+type webViewErrorEvent = Event.syntheticEvent(Js.t(webViewError));
+type webViewNavigationEvent = Event.syntheticEvent(Js.t(webViewNavigation));
+type webViewErrorOrNavigationEvent =
+  Event.syntheticEvent(Js.t(webViewErrorOrNavigation));
+type webViewMessageEvent = Event.syntheticEvent(Js.t(webViewMessage));
+type webViewEvent = Js.t(webViewBaseEvent);
 
 type request = {
   .
@@ -72,11 +107,11 @@ external make:
     ~javaScriptEnabled: bool=?,
     ~mediaPlaybackRequiresUserAction: bool=?,
     ~mixedContentMode: [@bs.string] [ | `never | `always | `compatibility]=?,
-    ~onError: webViewEvent => unit=?,
-    ~onLoad: webViewEvent => unit=?,
-    ~onLoadEnd: webViewEvent => unit=?,
-    ~onLoadStart: webViewEvent => unit=?,
-    ~onMessage: messageEvent => unit=?,
+    ~onError: webViewErrorEvent => unit=?,
+    ~onLoad: webViewNavigationEvent => unit=?,
+    ~onLoadEnd: webViewErrorOrNavigation => unit=?,
+    ~onLoadStart: webViewNavigationEvent => unit=?,
+    ~onMessage: webViewMessageEvent => unit=?,
     ~onNavigationStateChange: webViewEvent => unit=?,
     ~onShouldStartLoadWithRequest: request => bool=?,
     ~originWhitelist: array(string)=?,
@@ -163,6 +198,6 @@ external make:
     ~testID: string=?
   ) =>
   React.element =
-  "WebView"
+  "WebView";
 
 ```

--- a/src/components/WebView.re
+++ b/src/components/WebView.re
@@ -22,17 +22,52 @@ module Source = {
 module DataDetectorTypes = WebView_DataDetectorTypes;
 module DecelerationRate = WebView_DecelerationRate;
 
-type messageEvent = Event.syntheticEvent({. "data": string});
+class type webViewBaseEvent = {
+  pub url: string;
+  pub title: string;
+  pub loading: bool;
+  pub canGoBack: bool;
+  pub canGoForward: bool;
+  pub lockIdentifier: int;
+};
 
-type webViewEvent =
-  Event.syntheticEvent({
-    .
-    "url": string,
-    "title": string,
-    "loading": bool,
-    "canGoBack": bool,
-    "canGoForward": bool,
-  });
+class type virtual webViewNavigation = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub navigationType: string;
+  pub mainDocumentURL: option(string);
+};
+
+class type virtual webViewError = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub domain: option(string);
+  pub code: int;
+  pub description: string;
+};
+
+class type virtual webViewErrorOrNavigation = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub domain: option(string);
+  pub code: option(int);
+  pub description: string;
+  pub navigationType: string;
+  pub mainDocumentURL: option(string);
+};
+
+class type virtual webViewMessage = {
+  as 'self;
+  constraint 'self = #webViewBaseEvent;
+  pub data: string;
+};
+
+type webViewErrorEvent = Event.syntheticEvent(Js.t(webViewError));
+type webViewNavigationEvent = Event.syntheticEvent(Js.t(webViewNavigation));
+type webViewErrorOrNavigationEvent =
+  Event.syntheticEvent(Js.t(webViewErrorOrNavigation));
+type webViewMessageEvent = Event.syntheticEvent(Js.t(webViewMessage));
+type webViewEvent = Js.t(webViewBaseEvent);
 
 type request = {
   .
@@ -65,11 +100,11 @@ external make:
     ~javaScriptEnabled: bool=?,
     ~mediaPlaybackRequiresUserAction: bool=?,
     ~mixedContentMode: [@bs.string] [ | `never | `always | `compatibility]=?,
-    ~onError: webViewEvent => unit=?,
-    ~onLoad: webViewEvent => unit=?,
-    ~onLoadEnd: webViewEvent => unit=?,
-    ~onLoadStart: webViewEvent => unit=?,
-    ~onMessage: messageEvent => unit=?,
+    ~onError: webViewErrorEvent => unit=?,
+    ~onLoad: webViewNavigationEvent => unit=?,
+    ~onLoadEnd: webViewErrorOrNavigation => unit=?,
+    ~onLoadStart: webViewNavigationEvent => unit=?,
+    ~onMessage: webViewMessageEvent => unit=?,
     ~onNavigationStateChange: webViewEvent => unit=?,
     ~onShouldStartLoadWithRequest: request => bool=?,
     ~originWhitelist: array(string)=?,


### PR DESCRIPTION
This PR adds additional fields to event types in the WebView component and does this by inheriting fields from a base object type `webViewBaseEvent` as is the case in the [Typescript bindings](https://github.com/react-native-community/react-native-webview/blob/7d0c4a798e559a7d64fbe3172ee93f58401d005c/src/WebViewTypes.ts#L81-L103).

Once we upgrade to bucklescript 6 and the [reason parser has been upgraded](https://github.com/facebook/reason/pull/2036) we will be able to express this far more succinctly through Inherited fields in object type (available since 4.06):

```reason
type webViewNavigation = {. "navigationType": string, ...webViewBaseEvent};
```

This PR also fixes an incorrect typing of the `onNavigationStateChange` props callback param, which should not be wrapped in `Event.syntheticEvent`.