### PR TITLE
Add constructor for section type in VirtualizedSectionList

### DIFF
--- a/src/components/VirtualizedSectionList.md
+++ b/src/components/VirtualizedSectionList.md
@@ -25,6 +25,7 @@ and section('item) = {
   "renderItem": option(renderItemCallback('item)),
   "ItemSeparatorComponent": option(unit => React.element),
   "keyExtractor": option(('item, int) => string),
+  "sectionData": option(sectionData),
 }
 and renderItemCallback('item) = renderItemProps('item) => React.element
 and renderSectionHeaderProps('item) = {. "section": section('item)}
@@ -39,6 +40,22 @@ and separatorProps('item) = {
   "trailingItem": option('item),
   "trailingSection": option(section('item)),
 };
+
+[@bs.obj]
+external section:
+  (
+    ~data: array('item),
+    ~key: string=?,
+    ~renderItem: renderItemCallback('item)=?,
+    ~_ItemSeparatorComponent: unit => React.element=?,
+    ~keyExtractor: ('item, int) => string=?,
+    ~sectionData: sectionData=?,
+    unit
+  ) =>
+  section('item) =
+  "";
+
+external sectionData: 'a => sectionData = "%identity";
 
 [@react.component] [@bs.module "react-native"]
 external make:

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -1,5 +1,7 @@
 include VirtualizedListElement;
 
+type sectionData;
+
 type renderItemProps('item) = {
   .
   "item": 'item,
@@ -18,6 +20,7 @@ and section('item) = {
   "renderItem": option(renderItemCallback('item)),
   "ItemSeparatorComponent": option(unit => React.element),
   "keyExtractor": option(('item, int) => string),
+  "sectionData": option(sectionData),
 }
 and renderItemCallback('item) = renderItemProps('item) => React.element
 and renderSectionHeaderProps('item) = {. "section": section('item)}
@@ -32,6 +35,22 @@ and separatorProps('item) = {
   "trailingItem": option('item),
   "trailingSection": option(section('item)),
 };
+
+[@bs.obj]
+external section:
+  (
+    ~data: array('item),
+    ~key: string=?,
+    ~renderItem: renderItemCallback('item)=?,
+    ~_ItemSeparatorComponent: unit => React.element=?,
+    ~keyExtractor: ('item, int) => string=?,
+    ~sectionData: sectionData=?,
+    unit
+  ) =>
+  section('item) =
+  "";
+
+external sectionData: 'a => sectionData = "%identity";
 
 [@react.component] [@bs.module "react-native"]
 external make:


### PR DESCRIPTION
Should close #605 

Notes on implementation:

- `section` needs to be consumed as well as constructed, therefore I added a constructor after the type definition. This works without any issues, as tested for this case but also from prior experience.
- To avoid confusion with `extraData`, I chose the name `moreFields`.
- If the additional key `moreFields` was another parameter (`'moreFields`), then `section` would need to be typed as `section('item, 'moreFields)` which necessitates specifying `'moreFields` when creating `section` - if the key is not used. To avoid such unnecessary complexity, I chose to define a `moreFields` type instead and added a function to cast anything as that type.