### PR TITLE
Add binding to useWindowDimensions hook

### DIFF
--- a/src/apis/Dimensions.md
+++ b/src/apis/Dimensions.md
@@ -5,7 +5,7 @@ wip: true
 ---
 
 ```reason
-type t = {
+type displayMetrics = {
   .
   "width": float,
   "height": float,
@@ -15,12 +15,12 @@ type t = {
 
 type handler = {
   .
-  "screen": t,
-  "window": t,
+  "screen": displayMetrics,
+  "window": displayMetrics,
 };
 
 [@bs.module "react-native"] [@bs.scope "Dimensions"]
-external get: ([@bs.string] [ | `window | `screen]) => t = "";
+external get: ([@bs.string] [ | `window | `screen]) => displayMetrics = "";
 [@bs.module "react-native"] [@bs.scope "Dimensions"]
 external addEventListener: ([@bs.string] [ | `change], handler => unit) => unit =
   "";
@@ -28,5 +28,8 @@ external addEventListener: ([@bs.string] [ | `change], handler => unit) => unit 
 external removeEventListener:
   ([@bs.string] [ | `change], handler => unit) => unit =
   "";
+
+[@bs.module "react-native"]
+external useWindowDimensions: unit => displayMetrics = "useWindowDimensions";
 
 ```

--- a/src/apis/Dimensions.re
+++ b/src/apis/Dimensions.re
@@ -1,4 +1,4 @@
-type t = {
+type displayMetrics = {
   .
   "width": float,
   "height": float,
@@ -8,12 +8,12 @@ type t = {
 
 type handler = {
   .
-  "screen": t,
-  "window": t,
+  "screen": displayMetrics,
+  "window": displayMetrics,
 };
 
 [@bs.module "react-native"] [@bs.scope "Dimensions"]
-external get: ([@bs.string] [ | `window | `screen]) => t = "";
+external get: ([@bs.string] [ | `window | `screen]) => displayMetrics = "";
 [@bs.module "react-native"] [@bs.scope "Dimensions"]
 external addEventListener: ([@bs.string] [ | `change], handler => unit) => unit =
   "";
@@ -21,3 +21,6 @@ external addEventListener: ([@bs.string] [ | `change], handler => unit) => unit 
 external removeEventListener:
   ([@bs.string] [ | `change], handler => unit) => unit =
   "";
+
+[@bs.module "react-native"]
+external useWindowDimensions: unit => displayMetrics = "useWindowDimensions";


### PR DESCRIPTION
This hook has been added in RN 0.61.0 and is (according to the release notes) intended to replace most uses of various `Dimensions` methods.

`Dimensions.t` type is called `DisplayMetrics` in RN, and that type has accordingly been renamed `displayMetrics`.