### PR TITLE
Alert docs & binding adaptions

### DIFF
--- a/src/apis/Alert.md
+++ b/src/apis/Alert.md
@@ -4,44 +4,31 @@ title: Alert
 wip: true
 ---
 
+## Methods
+
+### `alert`
+
+Launches an alert dialog with the specified `title` and `message`. Optionally,
+an array of `buttons` can be provided: on Android the maximum is 3, on iOS any
+number is okay.
+
+On Android, the dialog can be dismissed by tapping outside of the alert box.
+This triggers the `onDismiss` callback available in the `options`. With the
+`cancelable` option, this behavior can be deactivated altogether.
+
+#### `alert` Example
+
 ```reason
-type options;
+  open ReactNative;
 
-[@bs.obj]
-external options:
-  (~cancelable: bool=?, ~onDismiss: unit => unit=?, unit) => options =
-  "";
-
-type button;
-
-[@bs.obj]
-external button:
-  (
-    ~text: string=?,
-    ~onPress: unit => unit=?,
-    ~style: [@bs.string] [ | `default | `cancel | `destructive]=?,
-    unit
-  ) =>
-  button =
-  "";
-
-[@bs.scope "Alert"] [@bs.module "react-native"]
-external alert:
-  (
-    ~title: string,
-    ~message: string=?,
-    ~buttons: array(button)=?,
-    ~options: options=?,
-    ~type_: [@bs.string] [
-              | `default
-              | `plainText
-              | `secureText
-              | `loginPassword
-            ]
-              =?,
-    unit
-  ) =>
-  unit =
-  "";
-
+  Alert.alert(
+    ~title="Do you really want to quit?",
+    ~message="We miss you already.",
+    ~buttons=[|
+      Alert.button(~text="OK", ~style=`destructive, ~onPress={() => Js.log("Bye!")}, ()),
+      Alert.button(~text="Cancel", ~style=`cancel, ()),
+    |],
+    ~options=Alert.options(~cancelable=true, ~onDismiss={_ => Js.log("Dismissed.")}, ()),
+    (),
+  );
 ```

--- a/src/apis/Alert.re
+++ b/src/apis/Alert.re
@@ -28,4 +28,28 @@ external alert:
     unit
   ) =>
   unit =
-  "";
+  "alert";
+
+[@bs.scope "Alert"] [@bs.module "react-native"]
+external prompt:
+  (
+    ~title: string,
+    ~message: string=?,
+    ~callbackOrButtons: [@bs.unwrap] [
+                          | `callback(string => unit)
+                          | `buttons(array(button))
+                        ]
+                          =?,
+    ~type_: [@bs.string] [
+              | `default
+              | [@bs.as "plain-text"] `plainText
+              | [@bs.as "secure-text"] `secureText
+              | [@bs.as "login-password"] `loginPassword
+            ]
+              =?,
+    ~defaultValue: string=?,
+    ~keyboardType: string=?,
+    unit
+  ) =>
+  unit =
+  "prompt";

--- a/src/apis/Alert.re
+++ b/src/apis/Alert.re
@@ -25,13 +25,6 @@ external alert:
     ~message: string=?,
     ~buttons: array(button)=?,
     ~options: options=?,
-    ~type_: [@bs.string] [
-              | `default
-              | `plainText
-              | `secureText
-              | `loginPassword
-            ]
-              =?,
     unit
   ) =>
   unit =


### PR DESCRIPTION
I wanted to write a blogpost about zero-cost bindings and take RN as an example. I compared the react-native sources to our bindings and found an error - there is no type field (anymore). They also mention the type field in the docs - so I sent them a PR too.

I took this opportunity to write a little documentation about Alert.

