### PR TITLE
add getters for Style props

### DIFF
--- a/src/apis/Style.bs.js
+++ b/src/apis/Style.bs.js
@@ -1,6 +1,8 @@
 'use strict';
 
 
+var GetProp = { };
+
 function pct(num) {
   return num.toString() + "%";
 }
@@ -13,6 +15,7 @@ function rad(num) {
   return num.toString() + "rad";
 }
 
+exports.GetProp = GetProp;
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;

--- a/src/apis/Style.re
+++ b/src/apis/Style.re
@@ -15,11 +15,6 @@ external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
 
 external unsafeStyle: Js.t('a) => t = "%identity";
 
-module GetProp = {
-  [@bs.get_index] external float: (t, [@bs.string] [ | `flex | `fontSize]) => option(float) = "";
-  [@bs.get_index] external string: (t, [@bs.string] [ | `fontFamily | `borderStyle]) => option(string) = "";
-};
-
 type size = string;
 
 external pt: float => size = "%identity";
@@ -55,6 +50,19 @@ type transform;
 // @todo matrix
 
 external unsafeTransform: Js.t('a) => transform = "%identity";
+
+module GetProp = {
+  type key = string;
+
+  external readKey: key => string = "%identity";
+
+  [@bs.val] external keys: t => array(key) = "Object.keys";
+
+  [@bs.get_index] external color: (t, key) => Color.t = "";
+  [@bs.get_index] external float: (t, key) => float = "";
+  [@bs.get_index] external size: (t, key) => size = "";
+  [@bs.get_index] external string: (t, key) => string = "";
+};
 
 // Styles are documented here
 // https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetTypes.js

--- a/src/apis/Style.re
+++ b/src/apis/Style.re
@@ -15,6 +15,11 @@ external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
 
 external unsafeStyle: Js.t('a) => t = "%identity";
 
+module GetProp = {
+  [@bs.get_index] external float: (t, [@bs.string] [ | `flex | `fontSize]) => option(float) = "";
+  [@bs.get_index] external string: (t, [@bs.string] [ | `fontFamily | `borderStyle]) => option(string) = "";
+};
+
 type size = string;
 
 external pt: float => size = "%identity";

--- a/src/apis/Style.rei
+++ b/src/apis/Style.rei
@@ -9,11 +9,6 @@ external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
   "Object.assign";
 external unsafeStyle: Js.t('a) => t = "%identity";
 
-module GetProp: {
-  [@bs.get_index] external float: (t, [@bs.string] [ | `flex | `fontSize]) => option(float) = "";
-  [@bs.get_index] external string: (t, [@bs.string] [ | `fontFamily | `borderStyle]) => option(string) = "";
-};
-
 type size;
 
 [@deprecated
@@ -53,6 +48,19 @@ type transform;
 // @todo matrix
 
 external unsafeTransform: Js.t('a) => transform = "%identity";
+
+module GetProp: {
+  type key;
+
+  external readKey: key => string = "%identity";
+
+  [@bs.val] external keys: t => array(key) = "Object.keys";
+
+  [@bs.get_index] external color: (t, key) => Color.t = "";
+  [@bs.get_index] external float: (t, key) => float = "";
+  [@bs.get_index] external size: (t, key) => size = "";
+  [@bs.get_index] external string: (t, key) => string = "";
+};
 
 // Styles are documented here
 // https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetTypes.js

--- a/src/apis/Style.rei
+++ b/src/apis/Style.rei
@@ -9,6 +9,11 @@ external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
   "Object.assign";
 external unsafeStyle: Js.t('a) => t = "%identity";
 
+module GetProp: {
+  [@bs.get_index] external float: (t, [@bs.string] [ | `flex | `fontSize]) => option(float) = "";
+  [@bs.get_index] external string: (t, [@bs.string] [ | `fontFamily | `borderStyle]) => option(string) = "";
+};
+
 type size;
 
 [@deprecated


### PR DESCRIPTION
This PR is to solicit feedback on another approach to address #619.

Basically, the idea is to define a getter for each type prop value, taking advantage of `[@bs.string]` to restrict the keys to valid props.  We would have to list all relevant polymorphic variants for each getter but that's a manageable problem. We could add an unsafe getter to handle any values set by the unsafe methods already included in `Style`.

The main drawback is that we probably have to define functions to match getter output to values such as `` `alignLeft`` but perhaps users can handle that themselves.