### PR TITLE
Add accessibilityRole and accessibilityLevel props

### DIFF
--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -16,44 +16,46 @@ external make:
     ~accessibilityHint: string=?,
     ~accessibilityLabel: string=?,
     ~allowFontScaling: bool=?,
+    // `accessibilityRole` communicates the purpose of a component to the user of an assistive technology.
+    // roles that are specific for react-native-web are also included:
+    // article, banner, complementary, contentinfo, form, list, listItem, main, navigation, region
     ~accessibilityRole: [@bs.string] [
                           | `none
-                          | `button
-                          | `link
-                          | `search
-                          | `image
-                          | `keyboardkey
-                          | `text
                           | `adjustable
-                          | `imagebutton
-                          | `header
-                          | `summary
                           | `alert
+                          | `article
+                          | `banner
+                          | `button
                           | `checkbox
                           | `combobox
+                          | `complementary
+                          | `contentinfo
+                          | `form
+                          | `header
+                          | `image
+                          | `imagebutton
+                          | `keyboardkey
+                          | `link
+                          | `list
+                          | `listItem
+                          | `search
+                          | `summary
+                          | `text
+                          | `main
                           | `menu
                           | `menubar
                           | `menuitem
+                          | `navigation
                           | `progressbar
                           | `radio
                           | `radiogroup
+                          | `region
                           | `scrollbar
                           | `spinbutton
                           | `tab
                           | `tablist
                           | `timer
                           | `toolbar
-                          // below are additional roles added for react-native-web https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js#L13-L23
-                          | `article
-                          | `banner
-                          | `complementary
-                          | `contentinfo
-                          | `form
-                          | `list
-                          | `listItem
-                          | `main
-                          | `navigation
-                          | `region
                         ]
                           =?,
     ~ariaLevel: int=?,

--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -43,6 +43,17 @@ external make:
                           | `tablist
                           | `timer
                           | `toolbar
+                          // below are additional roles added for react-native-web https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js#L13-L23
+                          | `article
+                          | `banner
+                          | `complementary
+                          | `contentinfo
+                          | `form
+                          | `list
+                          | `listItem
+                          | `main
+                          | `navigation
+                          | `region
                         ]
                           =?,
     ~ariaLevel: int=?,

--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -27,7 +27,6 @@ external make:
                           | `adjustable
                           | `imagebutton
                           | `header
-                          | `heading
                           | `summary
                           | `alert
                           | `checkbox

--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -45,7 +45,7 @@ external make:
                           | `toolbar
                         ]
                           =?,
-    ~accessibilityLevel: int=?,
+    ~ariaLevel: int=?,
     ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
     ~numberOfLines: int=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -16,6 +16,37 @@ external make:
     ~accessibilityHint: string=?,
     ~accessibilityLabel: string=?,
     ~allowFontScaling: bool=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `imagebutton
+                          | `header
+                          | `heading
+                          | `summary
+                          | `alert
+                          | `checkbox
+                          | `combobox
+                          | `menu
+                          | `menubar
+                          | `menuitem
+                          | `progressbar
+                          | `radio
+                          | `radiogroup
+                          | `scrollbar
+                          | `spinbutton
+                          | `tab
+                          | `tablist
+                          | `timer
+                          | `toolbar
+                        ]
+                          =?,
+    ~accessibilityLevel: int=?,
     ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
     ~numberOfLines: int=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -37,7 +37,7 @@ external make:
                           | `toolbar
                         ]
                           =?,
-    ~accessibilityLevel: int=?,
+    ~ariaLevel: int=?,
     ~allowFontScaling: bool=?,
     ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
     ~numberOfLines: int=?,

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -19,7 +19,6 @@ external make:
                           | `adjustable
                           | `imagebutton
                           | `header
-                          | `heading
                           | `summary
                           | `alert
                           | `checkbox

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -8,44 +8,46 @@ external make:
     ~accessible: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityLabel: string=?,
+    // `accessibilityRole` communicates the purpose of a component to the user of an assistive technology.
+    // roles that are specific for react-native-web are also included:
+    // article, banner, complementary, contentinfo, form, list, listItem, main, navigation, region
     ~accessibilityRole: [@bs.string] [
-                          | // below are additional roles added for react-native-web https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js#L13-L23
-                            `none
-                          | `button
-                          | `link
-                          | `search
-                          | `image
-                          | `keyboardkey
-                          | `text
+                          | `none
                           | `adjustable
-                          | `imagebutton
-                          | `header
-                          | `summary
                           | `alert
+                          | `article
+                          | `banner
+                          | `button
                           | `checkbox
                           | `combobox
+                          | `complementary
+                          | `contentinfo
+                          | `form
+                          | `header
+                          | `image
+                          | `imagebutton
+                          | `keyboardkey
+                          | `link
+                          | `list
+                          | `listItem
+                          | `search
+                          | `summary
+                          | `text
+                          | `main
                           | `menu
                           | `menubar
                           | `menuitem
+                          | `navigation
                           | `progressbar
                           | `radio
                           | `radiogroup
+                          | `region
                           | `scrollbar
                           | `spinbutton
                           | `tab
                           | `tablist
                           | `timer
                           | `toolbar
-                          | `article
-                          | `banner
-                          | `complementary
-                          | `contentinfo
-                          | `form
-                          | `list
-                          | `listItem
-                          | `main
-                          | `navigation
-                          | `region
                         ]
                           =?,
     ~ariaLevel: int=?,

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -9,7 +9,8 @@ external make:
     ~accessibilityHint: string=?,
     ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
-                          | `none
+                          | // below are additional roles added for react-native-web https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js#L13-L23
+                            `none
                           | `button
                           | `link
                           | `search
@@ -35,6 +36,16 @@ external make:
                           | `tablist
                           | `timer
                           | `toolbar
+                          | `article
+                          | `banner
+                          | `complementary
+                          | `contentinfo
+                          | `form
+                          | `list
+                          | `listItem
+                          | `main
+                          | `navigation
+                          | `region
                         ]
                           =?,
     ~ariaLevel: int=?,

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -8,6 +8,37 @@ external make:
     ~accessible: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityLabel: string=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `imagebutton
+                          | `header
+                          | `heading
+                          | `summary
+                          | `alert
+                          | `checkbox
+                          | `combobox
+                          | `menu
+                          | `menubar
+                          | `menuitem
+                          | `progressbar
+                          | `radio
+                          | `radiogroup
+                          | `scrollbar
+                          | `spinbutton
+                          | `tab
+                          | `tablist
+                          | `timer
+                          | `toolbar
+                        ]
+                          =?,
+    ~accessibilityLevel: int=?,
     ~allowFontScaling: bool=?,
     ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
     ~numberOfLines: int=?,


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #635 
<!--
Add any information that might be useful
-->

Added `accessibilityRole` and `accessibilityLevel` props to Text component.

accessibilityLevel prop does not exist in `react-native` but will work in `react-native-web`

Ref: https://github.com/necolas/react-native-web/pull/402/files