### PR TITLE
Fix autoCompleteType prop for text input component

### DIFF
--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -94,7 +94,7 @@ external make:
                        | `none
                      ]
                        =?,
-    ~autoComplete: [@bs.string] [
+    ~autoCompleteType: [@bs.string] [
                      | `off
                      | `username
                      | `password

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -87,22 +87,22 @@ external make:
                        | `none
                      ]
                        =?,
-    ~autoComplete: [@bs.string] [
-                     | `off
-                     | `username
-                     | `password
-                     | `email
-                     | `name
-                     | `tel
-                     | [@bs.as "street-address"] `streetAddress
-                     | [@bs.as "postal-code"] `postalCode
-                     | [@bs.as "cc-number"] `ccNumber
-                     | [@bs.as "cc-csc"] `ccCsc
-                     | [@bs.as "cc-exp"] `ccExp
-                     | [@bs.as "cc-exp-month"] `ccExpMonth
-                     | [@bs.as "cc-exp-year"] `ccExpYear
-                   ]
-                     =?,
+    ~autoCompleteType: [@bs.string] [
+                         | `off
+                         | `username
+                         | `password
+                         | `email
+                         | `name
+                         | `tel
+                         | [@bs.as "street-address"] `streetAddress
+                         | [@bs.as "postal-code"] `postalCode
+                         | [@bs.as "cc-number"] `ccNumber
+                         | [@bs.as "cc-csc"] `ccCsc
+                         | [@bs.as "cc-exp"] `ccExp
+                         | [@bs.as "cc-exp-month"] `ccExpMonth
+                         | [@bs.as "cc-exp-year"] `ccExpYear
+                       ]
+                         =?,
     ~autoCorrect: bool=?,
     ~autoFocus: bool=?,
     ~blurOnSubmit: bool=?,


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #634 

<!--
Add any information that might be useful
-->
Changed `autoComplete` prop in TextInput to `autoCompleteType`
React Native Ref: https://github.com/facebook/react-native/blob/master/Libraries/Components/TextInput/TextInput.js#L313
