### PR TITLE
Re-add NativeEventEmitter.

### DIFF
--- a/src/apis/NativeEventEmitter.bs.js
+++ b/src/apis/NativeEventEmitter.bs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+
+var Subscription = /* module */[];
+
+exports.Subscription = Subscription;
+/* No side effect */

--- a/src/apis/NativeEventEmitter.md
+++ b/src/apis/NativeEventEmitter.md
@@ -1,0 +1,28 @@
+---
+id: apis/NativeEventEmitter
+title: NativeEventEmitter
+wip: true
+---
+
+```reason
+type t;
+
+type subscription;
+
+[@bs.new] [@bs.module "react-native"]
+external make: 'nativeModule => t = "NativeEventEmitter";
+
+[@bs.send]
+external addListener: (t, string, 'a => unit) => subscription = "addListener";
+
+[@bs.send]
+external removeAllListeners: (t, string) => unit = "removeAllListeners";
+
+[@bs.send]
+external removeSubscription: (t, subscription) => unit = "removeSubscription";
+
+module Subscription = {
+  [@bs.send] external remove: (subscription, unit) => unit = "remove";
+};
+
+```

--- a/src/apis/NativeEventEmitter.re
+++ b/src/apis/NativeEventEmitter.re
@@ -1,0 +1,19 @@
+type t;
+
+type subscription;
+
+[@bs.new] [@bs.module "react-native"]
+external make: 'nativeModule => t = "NativeEventEmitter";
+
+[@bs.send]
+external addListener: (t, string, 'a => unit) => subscription = "addListener";
+
+[@bs.send]
+external removeAllListeners: (t, string) => unit = "removeAllListeners";
+
+[@bs.send]
+external removeSubscription: (t, subscription) => unit = "removeSubscription";
+
+module Subscription = {
+  [@bs.send] external remove: (subscription, unit) => unit = "remove";
+};


### PR DESCRIPTION
`NativeEventEmitter` was already present in the old bindings (https://github.com/reason-react-native/bs-react-native/blob/master/src/nativeEventEmitter.re), but somehow got lost. Re-adding it.