### PR TITLE
feat: add mouse event for react-native-web

### DIFF
--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -74,7 +74,11 @@ external make:
     ~minimumFontScale: float=?,
     ~suppressHighlighting: bool=?,
     ~value: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // React Native Web Props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+
   ) =>
   React.element =
   "Text";

--- a/src/components/Text.md
+++ b/src/components/Text.md
@@ -76,9 +76,13 @@ external make:
     ~value: string=?,
     ~children: React.element=?,
     // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
-
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?,
   ) =>
   React.element =
   "Text";

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -69,8 +69,13 @@ external make:
     ~value: string=?,
     ~children: React.element=?,
     // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "Text";

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -67,7 +67,10 @@ external make:
     ~minimumFontScale: float=?,
     ~suppressHighlighting: bool=?,
     ~value: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // React Native Web Props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "Text";

--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -305,10 +305,14 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    // React Native Web props
+    // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
-
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?,
   ) =>
   React.element =
   "TextInput";

--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -304,7 +304,11 @@ external make:
     ~renderToHardwareTextureAndroid: bool=?,
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
-    ~testID: string=?
+    ~testID: string=?,
+    // React Native Web props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+
   ) =>
   React.element =
   "TextInput";

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -297,7 +297,10 @@ external make:
     ~renderToHardwareTextureAndroid: bool=?,
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
-    ~testID: string=?
+    ~testID: string=?,
+    // React Native Web props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "TextInput";

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -298,9 +298,14 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    // React Native Web props
+    // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "TextInput";

--- a/src/components/View.md
+++ b/src/components/View.md
@@ -91,9 +91,14 @@ external make:
     ~style: Style.t=?,
     ~testID: string=?,
     ~children: React.element=?,
-    // React Native Web props
+    // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?,
   ) =>
   React.element =
   "View";

--- a/src/components/View.md
+++ b/src/components/View.md
@@ -90,7 +90,10 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // React Native Web props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "View";

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -83,7 +83,10 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // React Native Web props
+    ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "View";

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -84,9 +84,14 @@ external make:
     ~style: Style.t=?,
     ~testID: string=?,
     ~children: React.element=?,
-    // React Native Web props
+    // React Native Web Props
+    ~onMouseDown: ReactEvent.Mouse.t => unit=?,
     ~onMouseEnter: ReactEvent.Mouse.t => unit=?,
-    ~onMouseLeave: ReactEvent.Mouse.t => unit=?
+    ~onMouseLeave: ReactEvent.Mouse.t => unit=?,
+    ~onMouseMove: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOver: ReactEvent.Mouse.t => unit=?,
+    ~onMouseOut: ReactEvent.Mouse.t => unit=?,
+    ~onMouseUp: ReactEvent.Mouse.t => unit=?
   ) =>
   React.element =
   "View";


### PR DESCRIPTION
Closes #645 

<!--
Add any information that might be useful
-->
Adding onMouseEnter, onMouseLeave props for View, Text, TextInput

ref: https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/View/filterSupportedProps.js
https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/Text/index.js
https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/View/index.js
https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/TextInput/index.js

