### PR TITLE
Press-event, href and target

### DIFF
--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -137,9 +137,7 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    ~children: React.element=?,
-    // temporary react-native-web-prop
-    ~useWindowScrolling: bool=?
+    ~children: React.element=?
   ) =>
   React.element =
   "ScrollView";

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -137,7 +137,9 @@ external make:
     ~shouldRasterizeIOS: bool=?,
     ~style: Style.t=?,
     ~testID: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // temporary react-native-web-prop
+    ~useWindowScrolling: bool=?
   ) =>
   React.element =
   "ScrollView";

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -72,8 +72,8 @@ external make:
     ~rel: [@bs.string] [
             | `alternate
             | `author
-            | `dnsPrefetch
-            | [@bs.as "dns-prefetch"] `icon
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
             | `license
             | `next
             | `pingback

--- a/src/components/Text.re
+++ b/src/components/Text.re
@@ -55,8 +55,8 @@ external make:
     ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
     ~numberOfLines: int=?,
     ~onLayout: Event.layoutEvent => unit=?,
-    ~onLongPress: unit => unit=?,
-    ~onPress: unit => unit=?,
+    ~onLongPress: Event.pressEvent => unit=?,
+    ~onPress: Event.pressEvent => unit=?,
     ~pressRetentionOffset: View.edgeInsets=?,
     ~selectable: bool=?,
     ~style: Style.t=?,
@@ -67,7 +67,27 @@ external make:
     ~minimumFontScale: float=?,
     ~suppressHighlighting: bool=?,
     ~value: string=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // escape hatches for react-native web:
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | `dnsPrefetch
+            | [@bs.as "dns-prefetch"] `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: [@bs.string] [ | `_blank | `_self | `_parent | `_top]=?
   ) =>
   React.element =
   "Text";

--- a/src/components/TouchableHighlight.re
+++ b/src/components/TouchableHighlight.re
@@ -53,7 +53,27 @@ external make:
     ~pressRetentionOffset: View.edgeInsets=?,
     ~testID: string=?,
     ~touchSoundDisabled: bool=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // escape hatches for react-native web:
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: [@bs.string] [ | `_blank | `_self | `_parent | `_top]=?
   ) =>
   React.element =
   "TouchableHighlight";

--- a/src/components/TouchableNativeFeedback.re
+++ b/src/components/TouchableNativeFeedback.re
@@ -65,7 +65,27 @@ external make:
     ~pressRetentionOffset: View.edgeInsets=?,
     ~testID: string=?,
     ~touchSoundDisabled: bool=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // escape hatches for react-native web:
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: [@bs.string] [ | `_blank | `_self | `_parent | `_top]=?
   ) =>
   React.element =
   "TouchableNativeFeedback";

--- a/src/components/TouchableOpacity.re
+++ b/src/components/TouchableOpacity.re
@@ -50,7 +50,27 @@ external make:
     ~pressRetentionOffset: View.edgeInsets=?,
     ~testID: string=?,
     ~touchSoundDisabled: bool=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // escape hatches for react-native web:
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: [@bs.string] [ | `_blank | `_self | `_parent | `_top]=?
   ) =>
   React.element =
   "TouchableOpacity";

--- a/src/components/TouchableWithoutFeedback.re
+++ b/src/components/TouchableWithoutFeedback.re
@@ -47,7 +47,27 @@ external make:
     ~pressRetentionOffset: View.edgeInsets=?,
     ~testID: string=?,
     ~touchSoundDisabled: bool=?,
-    ~children: React.element=?
+    ~children: React.element=?,
+    // escape hatches for react-native web:
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: [@bs.string] [ | `_blank | `_self | `_parent | `_top]=?
   ) =>
   React.element =
   "TouchableWithoutFeedback";

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -36,6 +36,16 @@ external make:
                           | `header
                           | `summary
                           | `imagebutton
+                          | `article
+                          | `banner
+                          | `complementary
+                          | `contentinfo
+                          | `form
+                          | `list
+                          | `listitem
+                          | `main
+                          | `navigation
+                          | `region
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,


### PR DESCRIPTION
This adds `href` and `target` for React-Native-Web (pretty important for accessibility and SEO). Additionally it fixes a bug where the press event was not passed in a `Text` component. This is related, because when you have client routing you'd want to provide a `href` and do a `preventDefault` on the press event. 