### PR TITLE
[0.62] Animated: setting useNativeDriver prop is required

### DIFF
--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -37,7 +37,7 @@ module ValueAnimations = (Val: Value) => {
         ~velocity: Val.jsValue,
         ~deceleration: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -73,7 +73,7 @@ module ValueAnimations = (Val: Value) => {
         ~damping: float=?,
         ~delay: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -101,7 +101,7 @@ module ValueAnimations = (Val: Value) => {
         ~duration: float=?,
         ~delay: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -249,7 +249,7 @@ external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 type eventOptions('a);
 [@bs.obj]
 external eventOptions:
-  (~listener: 'a=?, ~useNativeDriver: bool=?, unit) => eventOptions('a) =
+  (~listener: 'a=?, ~useNativeDriver: bool, unit) => eventOptions('a) =
   "";
 
 // multiple externals

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -31,7 +31,7 @@ module ValueAnimations = (Val: Value) => {
         ~velocity: Val.jsValue,
         ~deceleration: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -67,7 +67,7 @@ module ValueAnimations = (Val: Value) => {
         ~damping: float=?,
         ~delay: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -95,7 +95,7 @@ module ValueAnimations = (Val: Value) => {
         ~duration: float=?,
         ~delay: float=?,
         ~isInteraction: bool=?,
-        ~useNativeDriver: bool=?,
+        ~useNativeDriver: bool,
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?,
         unit
@@ -253,7 +253,7 @@ external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 type eventOptions('a);
 [@bs.obj]
 external eventOptions:
-  (~listener: 'a=?, ~useNativeDriver: bool=?, unit) => eventOptions('a) =
+  (~listener: 'a=?, ~useNativeDriver: bool, unit) => eventOptions('a) =
   "";
 
 // multiple externals


### PR DESCRIPTION
As of 0.62, `useNativeDriver` prop needs to be specified for `Animated` configurations. Otherwise a run time warning will be generated. While some may prefer to simply ignore these warnings, we can avoid them by making the prop required.