### PR TITLE
[0.62] remove accessibilityStates prop

### DIFF
--- a/src/components/ActivityIndicator.md
+++ b/src/components/ActivityIndicator.md
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ActivityIndicator.re
+++ b/src/components/ActivityIndicator.re
@@ -38,7 +38,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.md
+++ b/src/components/CheckBox.md
@@ -50,7 +50,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.re
+++ b/src/components/CheckBox.re
@@ -43,7 +43,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DatePickerIOS.md
+++ b/src/components/DatePickerIOS.md
@@ -61,7 +61,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DatePickerIOS.re
+++ b/src/components/DatePickerIOS.re
@@ -54,7 +54,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DrawerLayoutAndroid.md
+++ b/src/components/DrawerLayoutAndroid.md
@@ -58,7 +58,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DrawerLayoutAndroid.re
+++ b/src/components/DrawerLayoutAndroid.re
@@ -51,7 +51,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.md
+++ b/src/components/FlatList.md
@@ -151,7 +151,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.re
+++ b/src/components/FlatList.re
@@ -144,7 +144,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/KeyboardAvoidingView.md
+++ b/src/components/KeyboardAvoidingView.md
@@ -42,7 +42,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/KeyboardAvoidingView.re
+++ b/src/components/KeyboardAvoidingView.re
@@ -35,7 +35,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/MaskedViewIOS.md
+++ b/src/components/MaskedViewIOS.md
@@ -40,7 +40,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/MaskedViewIOS.re
+++ b/src/components/MaskedViewIOS.re
@@ -33,7 +33,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.md
+++ b/src/components/Picker.md
@@ -48,7 +48,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.re
+++ b/src/components/Picker.re
@@ -41,7 +41,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/PickerIOS.md
+++ b/src/components/PickerIOS.md
@@ -42,7 +42,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/PickerIOS.re
+++ b/src/components/PickerIOS.re
@@ -35,7 +35,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.md
+++ b/src/components/ProgressBarAndroid.md
@@ -53,7 +53,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.re
+++ b/src/components/ProgressBarAndroid.re
@@ -46,7 +46,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressViewIOS.md
+++ b/src/components/ProgressViewIOS.md
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressViewIOS.re
+++ b/src/components/ProgressViewIOS.re
@@ -38,7 +38,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/RefreshControl.md
+++ b/src/components/RefreshControl.md
@@ -48,7 +48,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/RefreshControl.re
+++ b/src/components/RefreshControl.re
@@ -41,7 +41,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SafeAreaView.md
+++ b/src/components/SafeAreaView.md
@@ -38,7 +38,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SafeAreaView.re
+++ b/src/components/SafeAreaView.re
@@ -31,7 +31,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.md
+++ b/src/components/ScrollView.md
@@ -160,7 +160,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -92,7 +92,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SectionList.md
+++ b/src/components/SectionList.md
@@ -155,7 +155,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SectionList.re
+++ b/src/components/SectionList.re
@@ -157,7 +157,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.md
+++ b/src/components/SegmentedControlIOS.md
@@ -52,7 +52,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.re
+++ b/src/components/SegmentedControlIOS.re
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Slider.md
+++ b/src/components/Slider.md
@@ -53,7 +53,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Slider.re
+++ b/src/components/Slider.re
@@ -46,7 +46,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.md
+++ b/src/components/SnapshotViewIOS.md
@@ -40,7 +40,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.re
+++ b/src/components/SnapshotViewIOS.re
@@ -33,7 +33,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Switch.md
+++ b/src/components/Switch.md
@@ -52,7 +52,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Switch.re
+++ b/src/components/Switch.re
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TabBarIOS.md
+++ b/src/components/TabBarIOS.md
@@ -46,7 +46,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,
@@ -156,7 +155,6 @@ module Item = {
                             | `imagebutton
                           ]
                             =?,
-      ~accessibilityStates: array(AccessibilityState.t)=?,
       ~accessibilityTraits: array(AccessibilityTrait.t)=?,
       ~accessibilityViewIsModal: bool=?,
       ~accessible: bool=?,

--- a/src/components/TabBarIOS.re
+++ b/src/components/TabBarIOS.re
@@ -39,7 +39,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,
@@ -149,7 +148,6 @@ module Item = {
                             | `imagebutton
                           ]
                             =?,
-      ~accessibilityStates: array(AccessibilityState.t)=?,
       ~accessibilityTraits: array(AccessibilityTrait.t)=?,
       ~accessibilityViewIsModal: bool=?,
       ~accessible: bool=?,

--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -260,7 +260,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -253,7 +253,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ToolbarAndroid.md
+++ b/src/components/ToolbarAndroid.md
@@ -65,7 +65,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ToolbarAndroid.re
+++ b/src/components/ToolbarAndroid.re
@@ -58,7 +58,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TouchableHighlight.md
+++ b/src/components/TouchableHighlight.md
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableHighlight.re
+++ b/src/components/TouchableHighlight.re
@@ -38,7 +38,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableNativeFeedback.md
+++ b/src/components/TouchableNativeFeedback.md
@@ -57,7 +57,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableNativeFeedback.re
+++ b/src/components/TouchableNativeFeedback.re
@@ -50,7 +50,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableOpacity.md
+++ b/src/components/TouchableOpacity.md
@@ -42,7 +42,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableOpacity.re
+++ b/src/components/TouchableOpacity.re
@@ -35,7 +35,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableWithoutFeedback.md
+++ b/src/components/TouchableWithoutFeedback.md
@@ -37,7 +37,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableWithoutFeedback.re
+++ b/src/components/TouchableWithoutFeedback.re
@@ -30,7 +30,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/View.md
+++ b/src/components/View.md
@@ -45,7 +45,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -48,7 +48,6 @@ external make:
                           | `region
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ViewPagerAndroid.md
+++ b/src/components/ViewPagerAndroid.md
@@ -56,7 +56,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ViewPagerAndroid.re
+++ b/src/components/ViewPagerAndroid.re
@@ -49,7 +49,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedList.md
+++ b/src/components/VirtualizedList.md
@@ -201,7 +201,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedList.re
+++ b/src/components/VirtualizedList.re
@@ -194,7 +194,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedSectionList.md
+++ b/src/components/VirtualizedSectionList.md
@@ -193,7 +193,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -192,7 +192,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/WebView.md
+++ b/src/components/WebView.md
@@ -151,7 +151,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/WebView.re
+++ b/src/components/WebView.re
@@ -144,7 +144,6 @@ external make:
                           | `imagebutton
                         ]
                           =?,
-    ~accessibilityStates: array(AccessibilityState.t)=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/types/AccessibilityState.bs.js
+++ b/src/types/AccessibilityState.bs.js
@@ -1,1 +1,0 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/types/AccessibilityState.re
+++ b/src/types/AccessibilityState.re
@@ -1,7 +1,0 @@
-type t = string;
-
-[@bs.inline]
-let selected = "selected";
-
-[@bs.inline]
-let disabled = "disabled";

--- a/src/types/AccessibilityState.rei
+++ b/src/types/AccessibilityState.rei
@@ -1,7 +1,0 @@
-type t;
-
-[@bs.inline "selected"]
-let selected: t;
-
-[@bs.inline "disabled"]
-let disabled: t;


### PR DESCRIPTION
As of 0.62, `accessibilityStates` prop has been removed.

Its replacement (`accessibilityState`) is missing from these bindings, but I will follow up with a PR to add that.