### PR TITLE
[0.62] add accessibilityState prop and constructor for related object

### DIFF
--- a/src/components/ActivityIndicator.md
+++ b/src/components/ActivityIndicator.md
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ActivityIndicator.re
+++ b/src/components/ActivityIndicator.re
@@ -38,6 +38,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.md
+++ b/src/components/CheckBox.md
@@ -50,6 +50,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.re
+++ b/src/components/CheckBox.re
@@ -43,6 +43,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DatePickerIOS.md
+++ b/src/components/DatePickerIOS.md
@@ -61,6 +61,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DatePickerIOS.re
+++ b/src/components/DatePickerIOS.re
@@ -54,6 +54,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DrawerLayoutAndroid.md
+++ b/src/components/DrawerLayoutAndroid.md
@@ -58,6 +58,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DrawerLayoutAndroid.re
+++ b/src/components/DrawerLayoutAndroid.re
@@ -51,6 +51,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.md
+++ b/src/components/FlatList.md
@@ -151,6 +151,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.re
+++ b/src/components/FlatList.re
@@ -144,6 +144,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/KeyboardAvoidingView.md
+++ b/src/components/KeyboardAvoidingView.md
@@ -42,6 +42,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/KeyboardAvoidingView.re
+++ b/src/components/KeyboardAvoidingView.re
@@ -35,6 +35,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/MaskedViewIOS.md
+++ b/src/components/MaskedViewIOS.md
@@ -40,6 +40,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/MaskedViewIOS.re
+++ b/src/components/MaskedViewIOS.re
@@ -33,6 +33,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.md
+++ b/src/components/Picker.md
@@ -48,6 +48,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.re
+++ b/src/components/Picker.re
@@ -41,6 +41,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/PickerIOS.md
+++ b/src/components/PickerIOS.md
@@ -42,6 +42,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/PickerIOS.re
+++ b/src/components/PickerIOS.re
@@ -35,6 +35,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.md
+++ b/src/components/ProgressBarAndroid.md
@@ -53,6 +53,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.re
+++ b/src/components/ProgressBarAndroid.re
@@ -46,6 +46,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressViewIOS.md
+++ b/src/components/ProgressViewIOS.md
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressViewIOS.re
+++ b/src/components/ProgressViewIOS.re
@@ -38,6 +38,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/RefreshControl.md
+++ b/src/components/RefreshControl.md
@@ -48,6 +48,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/RefreshControl.re
+++ b/src/components/RefreshControl.re
@@ -41,6 +41,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SafeAreaView.md
+++ b/src/components/SafeAreaView.md
@@ -38,6 +38,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SafeAreaView.re
+++ b/src/components/SafeAreaView.re
@@ -31,6 +31,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.md
+++ b/src/components/ScrollView.md
@@ -160,6 +160,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -92,6 +92,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SectionList.md
+++ b/src/components/SectionList.md
@@ -155,6 +155,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SectionList.re
+++ b/src/components/SectionList.re
@@ -157,6 +157,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.md
+++ b/src/components/SegmentedControlIOS.md
@@ -52,6 +52,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.re
+++ b/src/components/SegmentedControlIOS.re
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Slider.md
+++ b/src/components/Slider.md
@@ -53,6 +53,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Slider.re
+++ b/src/components/Slider.re
@@ -46,6 +46,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.md
+++ b/src/components/SnapshotViewIOS.md
@@ -40,6 +40,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.re
+++ b/src/components/SnapshotViewIOS.re
@@ -33,6 +33,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Switch.md
+++ b/src/components/Switch.md
@@ -52,6 +52,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Switch.re
+++ b/src/components/Switch.re
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TabBarIOS.md
+++ b/src/components/TabBarIOS.md
@@ -46,6 +46,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,
@@ -155,6 +156,7 @@ module Item = {
                             | `imagebutton
                           ]
                             =?,
+      ~accessibilityState: Accessibility.state=?,
       ~accessibilityTraits: array(AccessibilityTrait.t)=?,
       ~accessibilityViewIsModal: bool=?,
       ~accessible: bool=?,

--- a/src/components/TabBarIOS.re
+++ b/src/components/TabBarIOS.re
@@ -39,6 +39,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,
@@ -148,6 +149,7 @@ module Item = {
                             | `imagebutton
                           ]
                             =?,
+      ~accessibilityState: Accessibility.state=?,
       ~accessibilityTraits: array(AccessibilityTrait.t)=?,
       ~accessibilityViewIsModal: bool=?,
       ~accessible: bool=?,

--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -260,6 +260,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -253,6 +253,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ToolbarAndroid.md
+++ b/src/components/ToolbarAndroid.md
@@ -65,6 +65,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ToolbarAndroid.re
+++ b/src/components/ToolbarAndroid.re
@@ -58,6 +58,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TouchableHighlight.md
+++ b/src/components/TouchableHighlight.md
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableHighlight.re
+++ b/src/components/TouchableHighlight.re
@@ -38,6 +38,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableNativeFeedback.md
+++ b/src/components/TouchableNativeFeedback.md
@@ -57,6 +57,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableNativeFeedback.re
+++ b/src/components/TouchableNativeFeedback.re
@@ -50,6 +50,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableOpacity.md
+++ b/src/components/TouchableOpacity.md
@@ -42,6 +42,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableOpacity.re
+++ b/src/components/TouchableOpacity.re
@@ -35,6 +35,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableWithoutFeedback.md
+++ b/src/components/TouchableWithoutFeedback.md
@@ -37,6 +37,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/TouchableWithoutFeedback.re
+++ b/src/components/TouchableWithoutFeedback.re
@@ -30,6 +30,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,

--- a/src/components/View.md
+++ b/src/components/View.md
@@ -45,6 +45,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -48,6 +48,7 @@ external make:
                           | `region
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ViewPagerAndroid.md
+++ b/src/components/ViewPagerAndroid.md
@@ -56,6 +56,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ViewPagerAndroid.re
+++ b/src/components/ViewPagerAndroid.re
@@ -49,6 +49,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedList.md
+++ b/src/components/VirtualizedList.md
@@ -201,6 +201,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedList.re
+++ b/src/components/VirtualizedList.re
@@ -194,6 +194,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedSectionList.md
+++ b/src/components/VirtualizedSectionList.md
@@ -193,6 +193,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -192,6 +192,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/WebView.md
+++ b/src/components/WebView.md
@@ -151,6 +151,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/WebView.re
+++ b/src/components/WebView.re
@@ -144,6 +144,7 @@ external make:
                           | `imagebutton
                         ]
                           =?,
+    ~accessibilityState: Accessibility.state=?,
     ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/types/Accessibility.bs.js
+++ b/src/types/Accessibility.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/types/Accessibility.bs.js
+++ b/src/types/Accessibility.bs.js
@@ -1,1 +1,7 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+
+var mixed = "mixed";
+
+exports.mixed = mixed;
+/* No side effect */

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -1,0 +1,20 @@
+type state;
+type checked = string;
+
+[@bs.inline]
+let mixed = "mixed";
+
+external setChecked: bool => checked = "%identity";
+
+[@bs.obj]
+external state:
+  (
+    ~disabled: bool=?,
+    ~selected: bool=?,
+    ~checked: checked=?,
+    ~busy: bool=?,
+    ~expanded: bool=?,
+    unit
+  ) =>
+  state =
+  "";

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -1,10 +1,13 @@
 type state;
-type checked = string;
+type checked = bool;
 
 [@bs.inline]
-let mixed = "mixed";
+let checked = true;
 
-external setChecked: bool => checked = "%identity";
+[@bs.inline]
+let unchecked = false;
+
+let mixed: checked = "mixed"->Obj.magic;
 
 [@bs.obj]
 external state:

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -1,0 +1,20 @@
+type state;
+type checked;
+
+[@bs.inline "mixed"]
+let mixed: checked;
+
+external setChecked: bool => checked = "%identity";
+
+[@bs.obj]
+external state:
+  (
+    ~disabled: bool=?,
+    ~selected: bool=?,
+    ~checked: checked=?,
+    ~busy: bool=?,
+    ~expanded: bool=?,
+    unit
+  ) =>
+  state =
+  "";

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -1,10 +1,13 @@
 type state;
 type checked;
 
-[@bs.inline "mixed"]
-let mixed: checked;
+[@bs.inline true]
+let checked: checked;
 
-external setChecked: bool => checked = "%identity";
+[@bs.inline false]
+let unchecked: checked;
+
+let mixed: checked;
 
 [@bs.obj]
 external state:


### PR DESCRIPTION
This PR adds the replacement prop for `accessibilityStates` removed in 0.62.

Before merging, I'd appreciate some feedback on the API. I have chosen to add a module called `Accessibility` and a type called `state` with a constructor of the same name. I plan to add another type called `value` and again a constructor of that name to handle the `accessibilityValue` prop which also seems to be missing from our bindings.

The JS API necessitates some rather unpleasant choices for the `checked` field, which can take either a `bool` or the string `"mixed"`. Since `unwrap` is still unavailable, this PR defines a type `checked` in `Accessibility`, a function to type cast `bool` to `checked` and uses `bs.inline` to handle `"mixed"`.

