### PR TITLE
[0.62] TextInput: remove onTextInput and selectionState props

### DIFF
--- a/src/components/TextInput.md
+++ b/src/components/TextInput.md
@@ -15,20 +15,6 @@ type changeEvent =
     "text": string,
   });
 
-type textInputEvent =
-  Event.syntheticEvent({
-    .
-    "eventCount": int,
-    "previousText": string,
-    "range": {
-      .
-      "start": int,
-      "_end": int,
-    },
-    "target": int,
-    "text": string,
-  });
-
 type editingEvent =
   Event.syntheticEvent({
     .
@@ -171,7 +157,6 @@ external make:
     ~onScroll: scrollEvent => unit=?,
     ~onSelectionChange: selectionChangeEvent => unit=?,
     ~onSubmitEditing: editingEvent => unit=?,
-    ~onTextInput: textInputEvent => unit=?,
     ~placeholder: string=?,
     ~placeholderTextColor: Color.t=?,
     ~returnKeyLabel: string=?,
@@ -196,8 +181,8 @@ external make:
     ~secureTextEntry: bool=?,
     ~selection: selection=?,
     ~selectionColor: Color.t=?,
-    ~selectionState: 'documentSelectionState=?, // TODO
     ~selectTextOnFocus: bool=?,
+    ~showSoftInputOnFocus: bool=?,
     ~spellCheck: bool=?,
     ~textBreakStrategy: [@bs.string] [ | `balanced | `highQuality | `simple]=?,
     ~textContentType: [@bs.string] [

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -8,20 +8,6 @@ type changeEvent =
     "text": string,
   });
 
-type textInputEvent =
-  Event.syntheticEvent({
-    .
-    "eventCount": int,
-    "previousText": string,
-    "range": {
-      .
-      "start": int,
-      "_end": int,
-    },
-    "target": int,
-    "text": string,
-  });
-
 type editingEvent =
   Event.syntheticEvent({
     .
@@ -164,7 +150,6 @@ external make:
     ~onScroll: scrollEvent => unit=?,
     ~onSelectionChange: selectionChangeEvent => unit=?,
     ~onSubmitEditing: editingEvent => unit=?,
-    ~onTextInput: textInputEvent => unit=?,
     ~placeholder: string=?,
     ~placeholderTextColor: Color.t=?,
     ~returnKeyLabel: string=?,
@@ -189,8 +174,8 @@ external make:
     ~secureTextEntry: bool=?,
     ~selection: selection=?,
     ~selectionColor: Color.t=?,
-    ~selectionState: 'documentSelectionState=?, // TODO
     ~selectTextOnFocus: bool=?,
+    ~showSoftInputOnFocus: bool=?,
     ~spellCheck: bool=?,
     ~textBreakStrategy: [@bs.string] [ | `balanced | `highQuality | `simple]=?,
     ~textContentType: [@bs.string] [


### PR DESCRIPTION
Follows 0.62 to removes the `onTextInput` prop and `textInputEvent` type. `selectionState` was never implemented, but it's now removed from RN. 

Also adds the `showSoftInputOnFocus` prop, introduced with 0.60.5.