### PR TITLE
[0.62] Modal: add statusBarTranslucent prop

### DIFF
--- a/src/components/Modal.md
+++ b/src/components/Modal.md
@@ -28,6 +28,7 @@ external make:
                           | `overFullScreen
                         ]
                           =?,
+    ~statusBarTranslucent: bool=?,
     ~supportedOrientations: array(Orientation.t)=?,
     ~transparent: bool=?,
     ~visible: bool=?,

--- a/src/components/Modal.re
+++ b/src/components/Modal.re
@@ -26,6 +26,7 @@ external make:
                           | `overFullScreen
                         ]
                           =?,
+    ~statusBarTranslucent: bool=?,
     ~supportedOrientations: array(Orientation.t)=?,
     ~transparent: bool=?,
     ~visible: bool=?,


### PR DESCRIPTION
Allows modal to appear underneath a translucent StatusBar.