### PR TITLE
[0.62] add module for DevSettings API

### DIFF
--- a/src/apis/DevSettings.bs.js
+++ b/src/apis/DevSettings.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/apis/DevSettings.md
+++ b/src/apis/DevSettings.md
@@ -1,0 +1,18 @@
+---
+id: apis/DevSettings
+title: DevSettings
+wip: true
+---
+
+```reason
+type reason = string;
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external addMenuItem: (string, unit => 'a) => unit = "addMenuItem";
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external reload: unit => unit = "reload";
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external reloadWithReason: reason => unit = "reload";
+```

--- a/src/apis/DevSettings.re
+++ b/src/apis/DevSettings.re
@@ -1,0 +1,10 @@
+type reason = string;
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external addMenuItem: (string, unit => 'a) => unit = "addMenuItem";
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external reload: unit => unit = "reload";
+
+[@bs.scope "DevSettings"] [@bs.module "react-native"]
+external reloadWithReason: reason => unit = "reload";


### PR DESCRIPTION
Defined the `reason` type as `string` for the binding to be self-documenting.