### PR TITLE
[0.62] add fadingEdgeLength prop to FlatList, ScrollView, SectionList, etc.

### DIFF
--- a/src/components/FlatList.md
+++ b/src/components/FlatList.md
@@ -87,6 +87,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/FlatList.re
+++ b/src/components/FlatList.re
@@ -80,6 +80,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/ScrollView.md
+++ b/src/components/ScrollView.md
@@ -96,6 +96,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -28,6 +28,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/SectionList.md
+++ b/src/components/SectionList.md
@@ -91,6 +91,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/SectionList.re
+++ b/src/components/SectionList.re
@@ -93,6 +93,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/VirtualizedList.md
+++ b/src/components/VirtualizedList.md
@@ -137,6 +137,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/VirtualizedList.re
+++ b/src/components/VirtualizedList.re
@@ -130,6 +130,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/VirtualizedSectionList.md
+++ b/src/components/VirtualizedSectionList.md
@@ -129,6 +129,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -128,6 +128,7 @@ external make:
     ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
     ~directionalLockEnabled: bool=?,
     ~endFillColor: Color.t=?,
+    ~fadingEdgeLength: float=?,
     ~horizontal: bool=?,
     ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
     ~keyboardDismissMode: [@bs.string] [


### PR DESCRIPTION
According to documentation on 0.62, this prop has been added to `ScrollView` and `FlatList`. `SectionList`, `VirtualizedList` and `VirtualizedSectionList` inherit props from `ScrollView` and should also support this prop. That, however, has not been tested.

@MoOx should limit the prop to `ScrollView` and `FlatList` or not?