### PR TITLE
[0.62] DevSettings: add documentation, revise signatures

### DIFF
--- a/src/apis/DevSettings.md
+++ b/src/apis/DevSettings.md
@@ -1,18 +1,50 @@
 ---
 id: apis/DevSettings
 title: DevSettings
-wip: true
+officialDoc: https://reactnative.dev/docs/devsettings
 ---
 
+`DevSettings` provides methods for developers.
+
+## Types
+
+### `handler`
+
+Alias for `unit => unit`.
+
+### `reason`
+
+Alias for `string`.
+
+### `title`
+
+Alias for `string`.
+
+## Methods
+
+### `addMenuItem`
+
+To add a custom entry to the developer menu. As arguments, takes a `title` (of
+type `string`) and a `handler` function (of type `unit => unit`) to be called
+when the menu item is pressed.
+
 ```reason
-type reason = string;
+addMenuItem: (title, handler) => unit
+```
 
-[@bs.scope "DevSettings"] [@bs.module "react-native"]
-external addMenuItem: (string, unit => 'a) => unit = "addMenuItem";
+### `reload`
 
-[@bs.scope "DevSettings"] [@bs.module "react-native"]
-external reload: unit => unit = "reload";
+To trigger a reload of the application.
 
-[@bs.scope "DevSettings"] [@bs.module "react-native"]
-external reloadWithReason: reason => unit = "reload";
+```reason
+reload: unit => unit
+```
+
+### `reloadWithReason`
+
+To trigger a reload of the application, with a `reason` (of type `string`) which
+may be useful for debugging.
+
+```reason
+reloadWithReason: reason => unit
 ```

--- a/src/apis/DevSettings.re
+++ b/src/apis/DevSettings.re
@@ -1,7 +1,9 @@
+type handler = unit => unit;
 type reason = string;
+type title = string;
 
 [@bs.scope "DevSettings"] [@bs.module "react-native"]
-external addMenuItem: (string, unit => 'a) => unit = "addMenuItem";
+external addMenuItem: (title, handler) => unit = "addMenuItem";
 
 [@bs.scope "DevSettings"] [@bs.module "react-native"]
 external reload: unit => unit = "reload";


### PR DESCRIPTION
I made some slight revisions to function signatures, adding type aliases (`title` as alias for `string` and `handler` as alias for `unit => unit`) to make it easier to discover how to use these methods without having to refer to documentation. While the handler can return `mixed` in JS, that does not really provide any benefit, so I have revised that so that `handler` does not need a type parameter, such as `handler('a)`.

I have prepared documentation for the module, as well.
