### PR TITLE
replace ## accessors in examples

### DIFF
--- a/src/apis/LayoutAnimation.md
+++ b/src/apis/LayoutAnimation.md
@@ -123,7 +123,7 @@ below, before state is returned.
 ```reason
 open ReactNative;
 
-let windowWidth = Dimensions.get(`window)##width;
+let windowWidth = Dimensions.get(`window).width;
 
 type state = {register: bool};
 

--- a/src/apis/PanResponder.md
+++ b/src/apis/PanResponder.md
@@ -253,8 +253,8 @@ Then, the custom `PanResponder` can be used as below:
 ```reason
 open ReactNative;
 
-let windowHeight = Dimensions.get(`window)##height;
-let windowWidth = Dimensions.get(`window)##width;
+let windowHeight = Dimensions.get(`window).height;
+let windowWidth = Dimensions.get(`window).width;
 
 let containerStyle =
   Style.(


### PR DESCRIPTION
Replace `##` accessors now that `Dimensions.get` returns a record.