### PR TITLE
Fix Animated.ValueXY.getTranslateTransform(value) binding

### DIFF
--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -212,7 +212,7 @@ module ValueXY = {
   [@bs.new] [@bs.scope "Animated"] [@bs.module "react-native"]
   external create: jsValue => t = "ValueXY";
   [@bs.send] external getLayout: t => layout = "getLayout";
-  [@bs.send] external getTranslateTransform: t => translateTransform = "getTranslateTransform";
+  [@bs.send] external getTranslateTransform: t => array(Style.transform) = "getTranslateTransform";
 };
 
 [@bs.module "react-native"] [@bs.scope "Animated"]

--- a/src/apis/Animated.md
+++ b/src/apis/Animated.md
@@ -201,10 +201,6 @@ module ValueXY = {
 
   [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue;
 
-  type translateTransform = {
-    translateX: Value.t,
-    translateY: Value.t,
-  };
   type layout = {
     left: Value.t,
     top: Value.t,

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -202,10 +202,6 @@ module ValueXY = {
 
   [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue;
 
-  type translateTransform = {
-    translateX: Value.t,
-    translateY: Value.t,
-  };
   type layout = {
     left: Value.t,
     top: Value.t,
@@ -214,7 +210,7 @@ module ValueXY = {
   external create: jsValue => t = "ValueXY";
   [@bs.send] external getLayout: t => layout = "getLayout";
   [@bs.send]
-  external getTranslateTransform: t => translateTransform =
+  external getTranslateTransform: t => array(ReactNative.Style.transform) =
     "getTranslateTransform";
 };
 

--- a/src/apis/Animated.re
+++ b/src/apis/Animated.re
@@ -210,7 +210,7 @@ module ValueXY = {
   external create: jsValue => t = "ValueXY";
   [@bs.send] external getLayout: t => layout = "getLayout";
   [@bs.send]
-  external getTranslateTransform: t => array(ReactNative.Style.transform) =
+  external getTranslateTransform: t => array(Style.transform) =
     "getTranslateTransform";
 };
 


### PR DESCRIPTION
As explained [here](https://animationbook.codedaily.io/get-translate-transform/), `getTranslateTransform` does not return an object but an array of transform objects.