### PR TITLE
enable warning 105

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -16,6 +16,6 @@
       "subdirs": true
     }
   ],
-  "bsc-flags": ["-bs-no-version-header", "-warn-error @a", "-w @a-105"],
+  "bsc-flags": ["-bs-no-version-header", "-warn-error @a"],
   "bs-dependencies": ["reason-react"]
 }


### PR DESCRIPTION
Thanks to @idkjs we no longer need to disable warning 105, so I believe it makes sense to revert my commit that introduced that change.