### PR TITLE
Fix layout-event, and some refactoring

### DIFF
--- a/src/apis/Event.bs.js
+++ b/src/apis/Event.bs.js
@@ -1,1 +1,40 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+
+var Line = { };
+
+var TextLayout = {
+  Line: Line
+};
+
+var Layout = { };
+
+var LayoutEvent = {
+  Layout: Layout
+};
+
+var PressEvent = { };
+
+var Dimensions = { };
+
+var ContentOffset = { };
+
+var ContentInset = { };
+
+var ScrollEvent = {
+  ContentOffset: ContentOffset,
+  ContentInset: ContentInset
+};
+
+var SwitchChangePayload = { };
+
+var TargetEvent = { };
+
+exports.TextLayout = TextLayout;
+exports.LayoutEvent = LayoutEvent;
+exports.PressEvent = PressEvent;
+exports.Dimensions = Dimensions;
+exports.ScrollEvent = ScrollEvent;
+exports.SwitchChangePayload = SwitchChangePayload;
+exports.TargetEvent = TargetEvent;
+/* No side effect */

--- a/src/apis/Event.re
+++ b/src/apis/Event.re
@@ -63,38 +63,37 @@ type responderSyntheticEvent('a) = {
 };
 
 module TextLayout = {
-  module Line = {
-    type t = {
-      x: float,
-      y: float,
-      width: float,
-      height: float,
-      ascender: float, // verify
-      capHeight: float, // verify
-      descender: float, // verify
-      text: string,
-      xHeight: float // verify
-    };
+  type line = {
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    ascender: float, // verify
+    capHeight: float, // verify
+    descender: float, // verify
+    text: string,
+    xHeight: float // verify
   };
-  type t = {lines: array(Line.t)};
+  type t = {lines: array(line)};
+};
+
+module Layout = {
+  type t = {
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+  };
 };
 
 module LayoutEvent = {
-  module Layout = {
-    type t = {
-      x: float,
-      y: float,
-      width: float,
-      height: float,
-    };
-  };
   type t = {layout: Layout.t};
 };
 
 type layout = LayoutEvent.t;
 type layoutEvent = syntheticEvent(layout);
 
-type textLayout = TextLayout.Line.t;
+type textLayout = TextLayout.line;
 type textLayouts = TextLayout.t;
 type textLayoutEvent = syntheticEvent(textLayouts);
 
@@ -125,32 +124,28 @@ module Dimensions = {
 type dimensions = Dimensions.t;
 
 module ScrollEvent = {
-  module ContentOffset = {
-    type t = {
-      x: float,
-      y: float,
-    };
+  type contentOffset = {
+    x: float,
+    y: float,
   };
 
-  module ContentInset = {
-    type t = {
-      bottom: float,
-      left: float,
-      right: float,
-      top: float,
-    };
+  type contentInset = {
+    bottom: float,
+    left: float,
+    right: float,
+    top: float,
   };
 
   type t = {
-    contentInset: ContentInset.t,
-    contentOffset: ContentOffset.t,
+    contentInset: contentOffset,
+    contentOffset: contentInset,
     contentSize: dimensions,
     layoutMeasurement: dimensions,
   };
 };
 
-type contentOffset = ScrollEvent.ContentOffset.t;
-type contentInset = ScrollEvent.ContentInset.t;
+type contentOffset = ScrollEvent.contentOffset;
+type contentInset = ScrollEvent.contentInset;
 type scrollEventPayload = ScrollEvent.t;
 type scrollEvent = syntheticEvent(scrollEventPayload);
 

--- a/src/apis/Event.re
+++ b/src/apis/Event.re
@@ -62,70 +62,108 @@ type responderSyntheticEvent('a) = {
   },
 };
 
-type textLayout = {
-  x: float,
-  y: float,
-  width: float,
-  height: float,
-  ascender: float, // verify
-  capHeight: float, // verify
-  descender: float, // verify
-  text: string,
-  xHeight: float // verify
+module TextLayout = {
+  module Line = {
+    type t = {
+      x: float,
+      y: float,
+      width: float,
+      height: float,
+      ascender: float, // verify
+      capHeight: float, // verify
+      descender: float, // verify
+      text: string,
+      xHeight: float // verify
+    };
+  };
+  type t = {lines: array(Line.t)};
 };
 
-type layoutEvent = syntheticEvent(layout)
-and layout = {
-  x: float,
-  y: float,
-  width: float,
-  height: float,
+module LayoutEvent = {
+  module Layout = {
+    type t = {
+      x: float,
+      y: float,
+      width: float,
+      height: float,
+    };
+  };
+  type t = {layout: Layout.t};
 };
 
-type textLayoutEvent = syntheticEvent(textLayouts)
-and textLayouts = {lines: array(textLayout)};
+type layout = LayoutEvent.t;
+type layoutEvent = syntheticEvent(layout);
 
-type pressEventPayload = {
-  changedTouches: array(pressEventPayload),
-  force: float,
-  identifier: int,
-  locationX: float,
-  locationY: float,
-  pageX: float,
-  pageY: float,
-  target: Js.Nullable.t(float),
-  timestamp: float,
-  touches: array(pressEventPayload),
+type textLayout = TextLayout.Line.t;
+type textLayouts = TextLayout.t;
+type textLayoutEvent = syntheticEvent(textLayouts);
+
+module PressEvent = {
+  type t = {
+    changedTouches: array(t),
+    force: float,
+    identifier: int,
+    locationX: float,
+    locationY: float,
+    pageX: float,
+    pageY: float,
+    target: Js.Nullable.t(float),
+    timestamp: float,
+    touches: array(t),
+  };
 };
-
+type pressEventPayload = PressEvent.t;
 type pressEvent = responderSyntheticEvent(pressEventPayload);
 
-type contentOffset = {
-  x: float,
-  y: float,
+module Dimensions = {
+  type t = {
+    height: float,
+    width: float,
+  };
 };
 
-type dimensions = {
-  height: float,
-  width: float,
+type dimensions = Dimensions.t;
+
+module ScrollEvent = {
+  module ContentOffset = {
+    type t = {
+      x: float,
+      y: float,
+    };
+  };
+
+  module ContentInset = {
+    type t = {
+      bottom: float,
+      left: float,
+      right: float,
+      top: float,
+    };
+  };
+
+  type t = {
+    contentInset: ContentInset.t,
+    contentOffset: ContentOffset.t,
+    contentSize: dimensions,
+    layoutMeasurement: dimensions,
+  };
 };
 
-type scrollEvent = syntheticEvent(scrollEventPayload)
-and scrollEventPayload = {
-  contentInset,
-  contentOffset,
-  contentSize: dimensions,
-  layoutMeasurement: dimensions,
-}
-and contentInset = {
-  bottom: float,
-  left: float,
-  right: float,
-  top: float,
+type contentOffset = ScrollEvent.ContentOffset.t;
+type contentInset = ScrollEvent.ContentInset.t;
+type scrollEventPayload = ScrollEvent.t;
+type scrollEvent = syntheticEvent(scrollEventPayload);
+
+module SwitchChangePayload = {
+  type t = {value: bool};
 };
 
-type switchChangeEvent = syntheticEvent(switchChangePayload)
-and switchChangePayload = {value: bool};
+type switchChangePayload = SwitchChangePayload.t;
+type switchChangeEvent = syntheticEvent(switchChangePayload);
 
-type targetEvent = syntheticEvent(targetPayload)
-and targetPayload = {target: int};
+module TargetEvent = {
+  type t = {target: int};
+};
+
+type targetPayload = TargetEvent.t;
+type targetEvent = syntheticEvent(targetPayload);

--- a/src/apis/Event.re
+++ b/src/apis/Event.re
@@ -87,7 +87,8 @@ module Layout = {
 };
 
 module LayoutEvent = {
-  type t = {layout: Layout.t};
+  type layout = Layout.t;
+  type t = {layout};
 };
 
 type layout = LayoutEvent.t;


### PR DESCRIPTION
I refactored our app to the new `reason-react-native`. Great work!

I found a little bug where the layout event is incorrectly typed.

When using records (especially when field names are shared) it's a good practice to wrap the type in a module, otherwise inference doesn't work and annotating becomes very cumbersome.

So here the bugfix and also wrapped types. I also kept the original names so it's totally non-breaking.