### PR TITLE
Add support for callback refs.

### DIFF
--- a/src/elements/DrawerLayoutAndroidElement.re
+++ b/src/elements/DrawerLayoutAndroidElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include DrawerLayoutAndroidMethods.Make({
   type t = element;

--- a/src/elements/NativeElement.re
+++ b/src/elements/NativeElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include NativeMethods.Make({
   type t = element;

--- a/src/elements/Ref.bs.js
+++ b/src/elements/Ref.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/elements/Ref.re
+++ b/src/elements/Ref.re
@@ -1,0 +1,7 @@
+type t('element);
+
+type valueRef('element) = React.Ref.t(Js.nullable('element));
+type callbackRef('element) = Js.nullable('element) => unit;
+
+external value: valueRef('element) => t('element) = "%identity";
+external callback: callbackRef('element) => t('element) = "%identity";

--- a/src/elements/ScrollViewElement.re
+++ b/src/elements/ScrollViewElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include ScrollViewMethods.Make({
   type t = element;

--- a/src/elements/TextInputElement.re
+++ b/src/elements/TextInputElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include TextInputMethods.Make({
   type t = element;

--- a/src/elements/TouchableOpacityElement.re
+++ b/src/elements/TouchableOpacityElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include TouchableOpacityMethods.Make({
   type t = element;

--- a/src/elements/ViewPagerAndroidElement.re
+++ b/src/elements/ViewPagerAndroidElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include ViewPagerAndroidMethods.Make({
   type t = element;

--- a/src/elements/VirtualizedListElement.re
+++ b/src/elements/VirtualizedListElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include VirtualizedListMethods.Make({
   type t = element;

--- a/src/elements/VirtualizedSectionListElement.re
+++ b/src/elements/VirtualizedSectionListElement.re
@@ -1,5 +1,5 @@
 type element;
-type ref = React.Ref.t(Js.nullable(element));
+type ref = Ref.t(element);
 
 include VirtualizedSectionListMethods.Make({
   type t = element;


### PR DESCRIPTION
@MoOx @jfrolich This implements support of callback refs as discussed on Discord. It is a breaking change.

You would now use

```... ref={myRef->Ref.value} ...```

for "value refs" (like we have currently) and

```... ref={setRef->Ref.callback} ...```

for "callback refs".