### PR TITLE
useCallback to memoize callback ref

### DIFF
--- a/src/elements/Ref.re
+++ b/src/elements/Ref.re
@@ -4,4 +4,12 @@ type valueRef('element) = React.Ref.t(Js.nullable('element));
 type callbackRef('element) = Js.nullable('element) => unit;
 
 external value: valueRef('element) => t('element) = "%identity";
-external callback: callbackRef('element) => t('element) = "%identity";
+
+[@bs.module "react"]
+external callback:
+  (
+    [@bs.uncurry] (Js.nullable('element) => unit),
+    [@bs.as {json|[]|json}] _
+  ) =>
+  t('element) =
+  "useCallback";


### PR DESCRIPTION
As long as we need a function to type cast refs, we may enforce the `useCallback` pattern while creating callback refs.