### PR TITLE
[Accessibility] revise type checked

### DIFF
--- a/src/types/Accessibility.bs.js
+++ b/src/types/Accessibility.bs.js
@@ -1,7 +1,1 @@
-'use strict';
-
-
-var mixed = "mixed";
-
-exports.mixed = mixed;
-/* No side effect */
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -1,5 +1,5 @@
 type state;
-type checked = bool;
+type checked('a) = 'a;
 
 [@bs.inline]
 let checked = true;
@@ -7,14 +7,15 @@ let checked = true;
 [@bs.inline]
 let unchecked = false;
 
-let mixed: checked = "mixed"->Obj.magic;
+[@bs.inline]
+let mixed = "mixed";
 
 [@bs.obj]
 external state:
   (
     ~disabled: bool=?,
     ~selected: bool=?,
-    ~checked: checked=?,
+    ~checked: checked('a)=?,
     ~busy: bool=?,
     ~expanded: bool=?,
     unit

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -1,20 +1,21 @@
 type state;
-type checked;
+type checked('a);
 
 [@bs.inline true]
-let checked: checked;
+let checked: checked(bool);
 
 [@bs.inline false]
-let unchecked: checked;
+let unchecked: checked(bool);
 
-let mixed: checked;
+[@bs.inline "mixed"]
+let mixed: checked(string);
 
 [@bs.obj]
 external state:
   (
     ~disabled: bool=?,
     ~selected: bool=?,
-    ~checked: checked=?,
+    ~checked: checked('a)=?,
     ~busy: bool=?,
     ~expanded: bool=?,
     unit


### PR DESCRIPTION
Minor improvement through parametrising the type to inline as. Removes JS output.