### PR TITLE
[Style] use JS type conversion to simplify pct, deg and rad

### DIFF
--- a/src/apis/Style.bs.js
+++ b/src/apis/Style.bs.js
@@ -2,15 +2,15 @@
 
 
 function pct(num) {
-  return num.toString() + "%";
+  return num + "%";
 }
 
 function deg(num) {
-  return num.toString() + "deg";
+  return num + "deg";
 }
 
 function rad(num) {
-  return num.toString() + "rad";
+  return num + "rad";
 }
 
 exports.pct = pct;

--- a/src/apis/Style.re
+++ b/src/apis/Style.re
@@ -20,7 +20,9 @@ type size = string;
 external pt: float => size = "%identity";
 external dp: float => size = "%identity";
 
-let pct = num => num->Js.Float.toString ++ "%";
+external _stringSuffix: (float, string) => 'a = "#string_append";
+
+let pct = (num: float): string => _stringSuffix(num, "%");
 
 type margin = size;
 
@@ -31,8 +33,8 @@ type offset;
 [@bs.obj] external offset: (~height: float, ~width: float) => offset;
 
 type angle;
-let deg: float => angle = num => (num->Js.Float.toString ++ "deg")->Obj.magic;
-let rad: float => angle = num => (num->Js.Float.toString ++ "rad")->Obj.magic;
+let deg = (num: float): angle => _stringSuffix(num, "deg");
+let rad = (num: float): angle => _stringSuffix(num, "rad");
 
 type transform;
 [@bs.obj] external perspective: (~perspective: float) => transform;


### PR DESCRIPTION
Sadly the below is not supported by the compiler, at least for the moment.
```reason
external pct: (float, [@bs.as "%"] _) => string = "#string_append";
```
We can, however, still simplify `pct`, `deg` and `rad` by removing the explicit conversion to string.

Admittedly, the performance difference is not really benchmarkable; this is simply because it's possible :grin:.
