### PR TITLE
[Event] convert syntheticEvent to record

### DIFF
--- a/src/apis/Event.bs.js
+++ b/src/apis/Event.bs.js
@@ -1,36 +1,24 @@
 'use strict';
 
 
-var Line = { };
-
-var TextLayout = {
-  Line: Line
-};
+var TextLayout = { };
 
 var Layout = { };
 
-var LayoutEvent = {
-  Layout: Layout
-};
+var LayoutEvent = { };
 
 var PressEvent = { };
 
 var Dimensions = { };
 
-var ContentOffset = { };
-
-var ContentInset = { };
-
-var ScrollEvent = {
-  ContentOffset: ContentOffset,
-  ContentInset: ContentInset
-};
+var ScrollEvent = { };
 
 var SwitchChangePayload = { };
 
 var TargetEvent = { };
 
 exports.TextLayout = TextLayout;
+exports.Layout = Layout;
 exports.LayoutEvent = LayoutEvent;
 exports.PressEvent = PressEvent;
 exports.Dimensions = Dimensions;

--- a/src/apis/Event.re
+++ b/src/apis/Event.re
@@ -1,66 +1,79 @@
 // see https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js
 
-type syntheticEvent('a) = {
-  .
-  "bubbles": Js.Nullable.t(bool),
-  "cancelable": Js.Nullable.t(bool),
-  "currentTarget": float,
-  "defaultPrevented": Js.Nullable.t(bool),
-  "dispatchConfig": {. "registrationName": string},
-  "eventPhase": Js.Nullable.t(float),
-  [@bs.meth] "preventDefault": unit => unit,
-  [@bs.meth] "isDefaultPrevented": unit => bool,
-  [@bs.meth] "stopPropagation": unit => unit,
-  [@bs.meth] "isPropagationStopped": unit => bool,
-  "isTrusted": Js.Nullable.t(bool),
-  "nativeEvent": 'a,
-  [@bs.meth] "persist": unit => unit,
-  "target": Js.Nullable.t(float),
-  "timeStamp": float,
-  "_type": Js.Nullable.t(string),
+type syntheticEvent('a, 'b) = {
+  bubbles: Js.Nullable.t(bool),
+  cancelable: Js.Nullable.t(bool),
+  currentTarget: float,
+  defaultPrevented: Js.Nullable.t(bool),
+  dispatchConfig: registrationName,
+  eventPhase: Js.Nullable.t(float),
+  isTrusted: Js.Nullable.t(bool),
+  nativeEvent: 'a,
+  target: Js.Nullable.t(float),
+  timeStamp: float,
+  [@bs.as "type"]
+  _type: Js.Nullable.t(string),
+  touchHistory: 'b // this field can be omitted, making 'b a phantom type
+}
+and registrationName = {registrationName: string};
+
+// type responderSyntheticEvent('a) defined as type syntheticEvent('a, touchHistory)
+
+type touchHistory = {
+  indexOfSingleActiveTouch: float,
+  mostRecentTimeStamp: float,
+  numberActiveTouches: float,
+  touchBank: array(touchBank),
+}
+and touchBank = {
+  touchActive: bool,
+  startPageX: float,
+  startPageY: float,
+  startTimeStamp: float,
+  currentPageX: float,
+  currentPageY: float,
+  currentTimeStamp: float,
+  previousPageX: float,
+  previousPageY: float,
+  previousTimeStamp: float,
 };
 
-type responderSyntheticEvent('a) = {
-  .
-  // synthethicEvent keys
-  "bubbles": Js.Nullable.t(bool),
-  "cancelable": Js.Nullable.t(bool),
-  "currentTarget": float,
-  "defaultPrevented": Js.Nullable.t(bool),
-  "dispatchConfig": {. "registrationName": string},
-  "eventPhase": Js.Nullable.t(float),
-  [@bs.meth] "preventDefault": unit => unit,
-  [@bs.meth] "isDefaultPrevented": unit => bool,
-  [@bs.meth] "stopPropagation": unit => unit,
-  [@bs.meth] "isPropagationStopped": unit => bool,
-  "isTrusted": Js.Nullable.t(bool),
-  "nativeEvent": 'a,
-  [@bs.meth] "persist": unit => unit,
-  "target": Js.Nullable.t(float),
-  "timeStamp": float,
-  "_type": Js.Nullable.t(string),
-  // responderSyntheticEvent additional key
-  "touchHistory": {
-    .
-    "indexOfSingleActiveTouch": float,
-    "mostRecentTimeStamp": float,
-    "numberActiveTouches": float,
-    "touchBank":
-      array({
-        .
-        "touchActive": bool,
-        "startPageX": float,
-        "startPageY": float,
-        "startTimeStamp": float,
-        "currentPageX": float,
-        "currentPageY": float,
-        "currentTimeStamp": float,
-        "previousPageX": float,
-        "previousPageY": float,
-        "previousTimeStamp": float,
-      }),
-  },
-};
+[@bs.get] [@bs.return nullable]
+external bubbles: syntheticEvent('a, 'b) => option(bool) = "bubbles";
+[@bs.get] [@bs.return nullable]
+external cancelable: syntheticEvent('a, 'b) => option(bool) = "cancelable";
+[@bs.get]
+external currentTarget: syntheticEvent('a, 'b) => float = "currentTarget";
+[@bs.get] [@bs.return nullable]
+external defaultPrevented: syntheticEvent('a, 'b) => option(bool) =
+  "defaultPrevented";
+[@bs.get]
+external dispatchConfig: syntheticEvent('a, 'b) => registrationName =
+  "dispatchConfig";
+[@bs.get] [@bs.return nullable]
+external eventPhase: syntheticEvent('a, 'b) => option(float) = "eventPhase";
+[@bs.send]
+external preventDefault: syntheticEvent('a, 'b) => unit = "preventDefault";
+[@bs.send]
+external isDefaultPrevented: syntheticEvent('a, 'b) => bool =
+  "isDefaultPrevented";
+[@bs.send]
+external stopPropagation: syntheticEvent('a, 'b) => unit = "stopPropagation";
+[@bs.send]
+external isPropagationStopped: syntheticEvent('a, 'b) => bool =
+  "isPropagationStopped";
+[@bs.get] [@bs.return nullable]
+external isTrusted: syntheticEvent('a, 'b) => option(bool) = "isTrusted";
+[@bs.get] external nativeEvent: syntheticEvent('a, 'b) => 'a = "nativeEvent";
+[@bs.send] external persist: syntheticEvent('a, 'b) => unit = "persist";
+[@bs.get] [@bs.return nullable]
+external target: syntheticEvent('a, 'b) => option(float) = "target";
+[@bs.get] external timeStamp: syntheticEvent('a, 'b) => float = "timeStamp";
+[@bs.get] [@bs.return nullable]
+external _type: syntheticEvent('a, 'b) => option(string) = "type";
+[@bs.get]
+external touchHistory: syntheticEvent('a, touchHistory) => touchHistory =
+  "touchHistory";
 
 module TextLayout = {
   type line = {
@@ -92,11 +105,11 @@ module LayoutEvent = {
 };
 
 type layout = LayoutEvent.t;
-type layoutEvent = syntheticEvent(layout);
+type layoutEvent = syntheticEvent(layout, unit);
 
 type textLayout = TextLayout.line;
 type textLayouts = TextLayout.t;
-type textLayoutEvent = syntheticEvent(textLayouts);
+type textLayoutEvent = syntheticEvent(textLayouts, unit);
 
 module PressEvent = {
   type t = {
@@ -113,7 +126,7 @@ module PressEvent = {
   };
 };
 type pressEventPayload = PressEvent.t;
-type pressEvent = responderSyntheticEvent(pressEventPayload);
+type pressEvent = syntheticEvent(pressEventPayload, touchHistory);
 
 module Dimensions = {
   type t = {
@@ -148,18 +161,18 @@ module ScrollEvent = {
 type contentOffset = ScrollEvent.contentOffset;
 type contentInset = ScrollEvent.contentInset;
 type scrollEventPayload = ScrollEvent.t;
-type scrollEvent = syntheticEvent(scrollEventPayload);
+type scrollEvent = syntheticEvent(scrollEventPayload, unit);
 
 module SwitchChangePayload = {
   type t = {value: bool};
 };
 
 type switchChangePayload = SwitchChangePayload.t;
-type switchChangeEvent = syntheticEvent(switchChangePayload);
+type switchChangeEvent = syntheticEvent(switchChangePayload, unit);
 
 module TargetEvent = {
   type t = {target: int};
 };
 
 type targetPayload = TargetEvent.t;
-type targetEvent = syntheticEvent(targetPayload);
+type targetEvent = syntheticEvent(targetPayload, unit);

--- a/src/components/CheckBox.re
+++ b/src/components/CheckBox.re
@@ -1,11 +1,10 @@
 include NativeElement;
 
-type checkBoxEvent =
-  Event.syntheticEvent({
-    .
-    "target": int,
-    "value": bool,
-  });
+type checkBoxEvent = Event.syntheticEvent(checkBoxEventPayload, unit)
+and checkBoxEventPayload = {
+  target: int,
+  value: bool,
+};
 
 [@react.component] [@bs.module "react-native"]
 external make:

--- a/src/components/DrawerLayoutAndroid.re
+++ b/src/components/DrawerLayoutAndroid.re
@@ -1,6 +1,6 @@
 include DrawerLayoutAndroidElement;
 
-type drawerSlideEvent = Event.syntheticEvent(drawerSlidePayload)
+type drawerSlideEvent = Event.syntheticEvent(drawerSlidePayload, unit)
 and drawerSlidePayload = {offset: float};
 
 [@react.component] [@bs.module "react-native"]

--- a/src/components/Image.re
+++ b/src/components/Image.re
@@ -43,7 +43,7 @@ module DefaultSource = {
   external fromRequired: Packager.required => t = "%identity";
 };
 
-type imageLoadEvent = Event.syntheticEvent(imageLoadPayload)
+type imageLoadEvent = Event.syntheticEvent(imageLoadPayload, unit)
 and imageLoadPayload = {
   uri: Js.Nullable.t(string),
   source,
@@ -54,10 +54,10 @@ and source = {
   url: string,
 };
 
-type errorEvent = Event.syntheticEvent(errorPayload)
+type errorEvent = Event.syntheticEvent(errorPayload, unit)
 and errorPayload = {error: string};
 
-type progressEvent = Event.syntheticEvent(progressPayload)
+type progressEvent = Event.syntheticEvent(progressPayload, unit)
 and progressPayload = {
   loaded: float,
   total: float,

--- a/src/components/Modal.re
+++ b/src/components/Modal.re
@@ -3,7 +3,7 @@ include NativeElement;
 module Orientation = Modal_Orientation;
 module OrientationChange = Modal_OrientationChange;
 
-type orientationChange = Event.syntheticEvent(orientationChangePayload)
+type orientationChange = Event.syntheticEvent(orientationChangePayload, unit)
 and orientationChangePayload = {orientation: OrientationChange.t};
 
 [@react.component] [@bs.module "react-native"]

--- a/src/components/SegmentedControlIOS.re
+++ b/src/components/SegmentedControlIOS.re
@@ -12,7 +12,7 @@ external make:
     // SegmentedControlIOS props
     ~enabled: bool=?,
     ~momentary: bool=?,
-    ~onChange: Event.syntheticEvent(change) => unit=?,
+    ~onChange: Event.syntheticEvent(change, unit) => unit=?,
     ~onValueChange: int => unit=?,
     ~selectedIndex: int=?,
     ~tintColor: string=?,

--- a/src/components/SnapshotViewIOS.re
+++ b/src/components/SnapshotViewIOS.re
@@ -1,4 +1,4 @@
-type snapshotReady = Event.syntheticEvent(snapshotReadyPaylaod)
+type snapshotReady = Event.syntheticEvent(snapshotReadyPaylaod, unit)
 and snapshotReadyPaylaod = {testIdentifier: string};
 
 [@react.component] [@bs.module "react-native"]

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -1,20 +1,21 @@
 include TextInputElement;
 
-type changeEvent = Event.syntheticEvent(changePayload)
+type changeEvent = Event.syntheticEvent(changePayload, unit)
 and changePayload = {
   eventCount: int,
   target: int,
   text: string,
 };
 
-type editingEvent = Event.syntheticEvent(editingPayload)
+type editingEvent = Event.syntheticEvent(editingPayload, unit)
 and editingPayload = {
   text: string,
   eventCount: int,
   target: int,
 };
 
-type contentSizeChangeEvent = Event.syntheticEvent(contentSizeChangePayload)
+type contentSizeChangeEvent =
+  Event.syntheticEvent(contentSizeChangePayload, unit)
 and contentSizeChangePayload = {
   target: int,
   contentSize,
@@ -24,7 +25,7 @@ and contentSize = {
   height: float,
 };
 
-type scrollEvent = Event.syntheticEvent(scrollPayload)
+type scrollEvent = Event.syntheticEvent(scrollPayload, unit)
 and scrollPayload = {contentOffset}
 and contentOffset = {
   x: float,
@@ -37,13 +38,13 @@ type selection = {
   _end: int,
 };
 
-type selectionChangeEvent = Event.syntheticEvent(selectionChangePayload)
+type selectionChangeEvent = Event.syntheticEvent(selectionChangePayload, unit)
 and selectionChangePayload = {
   selection,
   target: int,
 };
 
-type keyPressEvent = Event.syntheticEvent(keyPressPayload)
+type keyPressEvent = Event.syntheticEvent(keyPressPayload, unit)
 and keyPressPayload = {
   key: string,
   target: Js.Nullable.t(int),


### PR DESCRIPTION
closes #688

I added another type parameter to `syntheticEvent` to handle the additional `touchHistory` key in `responderSyntheticEvent`.

Discussion points to settle:

• `touchHistory` may be included in the record definition, then what previously used to be `syntheticEvent('a)` becomes `syntheticEvent('a, unit)` and `responderSyntheticEvent('a)` becomes `syntheticEvent('a, touchHistory)`. My testing suggests `unit` is fine as type parameter `'b`, but given such events will have `undefined` as the value for `e.touchHistory`, `option(unit)` may be even safer as `e.touchHistory == None` would hold. 

• If `touchHistory` is not included in the definition, `'b` becomes a phantom type to ensure that the `touchHistory` method only can be applied on `syntheticEvent('a, touchHistory)`. As expected, `e.touchHistory` is not available.

• Should `type responderSyntheticEvent('a) = syntheticEvent('a, touchHistory);` still be included and `pressEvent` remain defined to be of type `responderSyntheticEvent('a)`? Not needed, obviously, but would keep closer to the JS definitions.

• `[@bs.send]` to handle keys previously decorated with `[@bs.meth]` as discussed before.

• `[@bs.get]` to define getters for all non-method fields to achieve consistency with `reason-react`. While the record has `Js.Nullable.t` types for some keys, IMO, using `[@bs.return nullable]` to return `option` types is a better API.

An alternative approach may be to define parametrized modules for `SyntheticEvent` and `ResponderSyntheticEvent` and then define each event as an instance of either. I think this approach is straightforward, but based on feedback I can work on that instead.