### PR TITLE
Fix a very minor typo in Global.re

### DIFF
--- a/src/apis/Global.re
+++ b/src/apis/Global.re
@@ -1,7 +1,7 @@
 [@bs.val] external __DEV__: bool = "__DEV__";
 
 [@bs.scope "global"] [@bs.val]
-external hermesInternal: option(Js.t('a)) = "hermesInternal";
+external hermesInternal: option(Js.t('a)) = "HermesInternal";
 
 [@bs.module "react-native"]
 external unstable_enableLogBox: unit => unit = "unstable_enableLogBox";


### PR DESCRIPTION
The JavaScript version of global.HermesInternal uses an uppercase H instead of lowercase. I assume it was a typo in reason.

<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md
Closes #<number-of-the-issue>
-->
<!--
Add any information that might be useful
-->
