### PR TITLE
Correct type of TouchableNativeFeedback.Background.canUseNativeForeground

### DIFF
--- a/src/components/TouchableNativeFeedback.md
+++ b/src/components/TouchableNativeFeedback.md
@@ -18,7 +18,7 @@ module Background = {
     "SelectableBackgroundBorderless";
 
   [@bs.module "react-native"] [@bs.scope "TouchableNativeFeedback"]
-  external canUseNativeForeground: unit => t = "CanUseNativeForeground";
+  external canUseNativeForeground: unit => bool = "canUseNativeForeground";
 
   [@bs.module "react-native"] [@bs.scope "TouchableNativeFeedback"]
   external ripple: (string, bool) => t = "Ripple";

--- a/src/components/TouchableNativeFeedback.re
+++ b/src/components/TouchableNativeFeedback.re
@@ -11,7 +11,7 @@ module Background = {
     "SelectableBackgroundBorderless";
 
   [@bs.module "react-native"] [@bs.scope "TouchableNativeFeedback"]
-  external canUseNativeForeground: unit => t = "CanUseNativeForeground";
+  external canUseNativeForeground: unit => bool = "canUseNativeForeground";
 
   [@bs.module "react-native"] [@bs.scope "TouchableNativeFeedback"]
   external ripple: (string, bool) => t = "Ripple";


### PR DESCRIPTION
As discussed with @MoOx in issue https://github.com/reason-react-native/reason-react-native/issues/702, this PR is to correct the type of TouchableNativeFeedback.Background.canUseNativeForeground.


Closes #702