### PR TITLE
Fix VirtualizedListMethods.scrollToItemParams.

### DIFF
--- a/src/elements/VirtualizedListMethods.re
+++ b/src/elements/VirtualizedListMethods.re
@@ -17,7 +17,7 @@ module Make = (T: {type t;}) => {
   [@bs.obj]
   external scrollToItemParams:
     (~viewPosition: float=?, ~animated: bool=?, ~item: 'item, unit) =>
-    scrollToIndexParams;
+    scrollToItemParams('item);
   [@bs.send]
   external scrollToItem: (T.t, scrollToItemParams('item)) => unit =
     "scrollToItem";


### PR DESCRIPTION
This fixes a copy and paste error.