### PR TITLE
Remove enableLogBox from Global

### DIFF
--- a/src/apis/Global.md
+++ b/src/apis/Global.md
@@ -23,19 +23,6 @@ else {
 }
 ```
 
-## `Global.unstable_enableLogBox``
-
-Enable React Native unstable
-[LogBox](https://reactnative.dev/blog/2020/03/26/version-0.62#other-improvements)
-
-```reason
-open ReactNative;
-
-if (Global.__DEV__) {
-  Global.unstable_enableLogBox();
-};
-```
-
 ## `Global.hermesInternal`
 
 This is the `HermesInternal` value known in JavaScript as

--- a/src/apis/Global.re
+++ b/src/apis/Global.re
@@ -2,6 +2,3 @@
 
 [@bs.scope "global"] [@bs.val]
 external hermesInternal: option(Js.t('a)) = "HermesInternal";
-
-[@bs.module "react-native"]
-external unstable_enableLogBox: unit => unit = "unstable_enableLogBox";


### PR DESCRIPTION
Removing enableLogBox from Global because RN63 will be using the new log box as the default logger. 

Related issues.
#705 

