### PR TITLE
Accessibility changes for 0.63

### DIFF
--- a/src/components/ActivityIndicator.re
+++ b/src/components/ActivityIndicator.re
@@ -35,6 +35,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/ActivityIndicator.re
+++ b/src/components/ActivityIndicator.re
@@ -13,7 +13,6 @@ external make:
     ~hidesWhenStopped: bool=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -21,7 +20,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.re
+++ b/src/components/CheckBox.re
@@ -24,7 +24,6 @@ external make:
     ~value: bool=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -32,7 +31,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/CheckBox.re
+++ b/src/components/CheckBox.re
@@ -46,6 +46,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/DatePickerIOS.re
+++ b/src/components/DatePickerIOS.re
@@ -31,7 +31,6 @@ external make:
     ~timeZoneOffsetInMinutes: int=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -39,7 +38,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/DatePickerIOS.re
+++ b/src/components/DatePickerIOS.re
@@ -53,6 +53,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/DrawerLayoutAndroid.re
+++ b/src/components/DrawerLayoutAndroid.re
@@ -62,6 +62,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/DrawerLayoutAndroid.re
+++ b/src/components/DrawerLayoutAndroid.re
@@ -40,7 +40,6 @@ external make:
     ~statusBarBackgroundColor: Color.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -48,7 +47,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.re
+++ b/src/components/FlatList.re
@@ -115,7 +115,6 @@ external make:
     ~zoomScale: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -123,7 +122,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/FlatList.re
+++ b/src/components/FlatList.re
@@ -137,6 +137,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/KeyboardAvoidingView.re
+++ b/src/components/KeyboardAvoidingView.re
@@ -34,6 +34,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/KeyboardAvoidingView.re
+++ b/src/components/KeyboardAvoidingView.re
@@ -12,7 +12,6 @@ external make:
     ~contentContainerStyle: Style.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -20,7 +19,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/MaskedViewIOS.re
+++ b/src/components/MaskedViewIOS.re
@@ -30,6 +30,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/MaskedViewIOS.re
+++ b/src/components/MaskedViewIOS.re
@@ -8,7 +8,6 @@ external make:
     ~maskElement: React.element,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -16,7 +15,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.re
+++ b/src/components/Picker.re
@@ -18,7 +18,6 @@ external make:
     ~itemStyle: Style.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -26,7 +25,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/Picker.re
+++ b/src/components/Picker.re
@@ -40,6 +40,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/PickerIOS.re
+++ b/src/components/PickerIOS.re
@@ -32,6 +32,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/PickerIOS.re
+++ b/src/components/PickerIOS.re
@@ -10,7 +10,6 @@ external make:
     ~itemStyle: Style.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -18,7 +17,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.re
+++ b/src/components/ProgressBarAndroid.re
@@ -22,7 +22,6 @@ external make:
     ~styleAttr: styleAttr=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -30,7 +29,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressBarAndroid.re
+++ b/src/components/ProgressBarAndroid.re
@@ -44,6 +44,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/ProgressViewIOS.re
+++ b/src/components/ProgressViewIOS.re
@@ -15,7 +15,6 @@ external make:
     ~trackTintColor: Color.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -23,7 +22,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ProgressViewIOS.re
+++ b/src/components/ProgressViewIOS.re
@@ -37,6 +37,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/RefreshControl.re
+++ b/src/components/RefreshControl.re
@@ -16,7 +16,6 @@ external make:
     ~titleColor: Color.t=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -24,7 +23,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/RefreshControl.re
+++ b/src/components/RefreshControl.re
@@ -38,6 +38,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/SafeAreaView.re
+++ b/src/components/SafeAreaView.re
@@ -27,6 +27,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/SafeAreaView.re
+++ b/src/components/SafeAreaView.re
@@ -5,7 +5,6 @@ external make:
   (
     ~ref: ref=?,
     // SafeAreaView props
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -13,7 +12,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -79,7 +79,6 @@ external make:
     ~zoomScale: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -87,7 +86,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/ScrollView.re
+++ b/src/components/ScrollView.re
@@ -101,6 +101,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/SectionList.re
+++ b/src/components/SectionList.re
@@ -160,6 +160,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/SectionList.re
+++ b/src/components/SectionList.re
@@ -138,7 +138,6 @@ external make:
     ~zoomScale: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -146,7 +145,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.re
+++ b/src/components/SegmentedControlIOS.re
@@ -27,7 +27,6 @@ external make:
     ~values: array(string)=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -35,7 +34,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SegmentedControlIOS.re
+++ b/src/components/SegmentedControlIOS.re
@@ -49,6 +49,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Slider.re
+++ b/src/components/Slider.re
@@ -43,6 +43,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Slider.re
+++ b/src/components/Slider.re
@@ -21,7 +21,6 @@ external make:
     ~value: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -29,7 +28,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.re
+++ b/src/components/SnapshotViewIOS.re
@@ -16,7 +16,6 @@ external make:
     ~testIdentifier: string=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -24,7 +23,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/SnapshotViewIOS.re
+++ b/src/components/SnapshotViewIOS.re
@@ -38,6 +38,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Switch.re
+++ b/src/components/Switch.re
@@ -40,6 +40,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/Switch.re
+++ b/src/components/Switch.re
@@ -18,7 +18,6 @@ external make:
     ~value: bool=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -26,7 +25,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -259,7 +259,6 @@ external make:
     ~value: string=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -267,7 +266,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/TextInput.re
+++ b/src/components/TextInput.re
@@ -281,6 +281,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/TouchableHighlight.re
+++ b/src/components/TouchableHighlight.re
@@ -14,7 +14,6 @@ external make:
     ~underlayColor: string=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -22,7 +21,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~delayLongPress: int=?,

--- a/src/components/TouchableNativeFeedback.re
+++ b/src/components/TouchableNativeFeedback.re
@@ -26,7 +26,6 @@ external make:
     ~useForeground: bool=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -34,7 +33,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~delayLongPress: int=?,

--- a/src/components/TouchableOpacity.re
+++ b/src/components/TouchableOpacity.re
@@ -11,7 +11,6 @@ external make:
     ~tvParallaxProperties: TV.parallax=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -19,7 +18,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~delayLongPress: int=?,

--- a/src/components/TouchableWithoutFeedback.re
+++ b/src/components/TouchableWithoutFeedback.re
@@ -6,7 +6,6 @@ external make:
     ~ref: ref=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -14,7 +13,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~delayLongPress: int=?,

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -22,7 +22,6 @@ external make:
     // ↓
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -30,7 +29,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/View.re
+++ b/src/components/View.re
@@ -44,6 +44,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/VirtualizedList.re
+++ b/src/components/VirtualizedList.re
@@ -158,7 +158,6 @@ external make:
     ~zoomScale: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -166,7 +165,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/components/VirtualizedList.re
+++ b/src/components/VirtualizedList.re
@@ -180,6 +180,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -186,6 +186,7 @@ external make:
                                   =?,
     ~nativeID: string=?,
     ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityAction: Accessibility.actionEvent => unit=?,
     ~onAccessibilityEscape: unit => unit=?,
     ~onAccessibilityTap: unit => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,

--- a/src/components/VirtualizedSectionList.re
+++ b/src/components/VirtualizedSectionList.re
@@ -164,7 +164,6 @@ external make:
     ~zoomScale: float=?,
     // View props 0.63.0
     ~accessibilityActions: array(Accessibility.actionInfo)=?,
-    ~accessibilityComponentType: Accessibility.componentType=?,
     ~accessibilityElementsHidden: bool=?,
     ~accessibilityHint: string=?,
     ~accessibilityIgnoresInvertColors: bool=?,
@@ -172,7 +171,6 @@ external make:
     ~accessibilityLiveRegion: Accessibility.liveRegion=?,
     ~accessibilityRole: Accessibility.role=?,
     ~accessibilityState: Accessibility.state=?,
-    ~accessibilityTraits: array(Accessibility.trait)=?,
     ~accessibilityValue: Accessibility.value=?,
     ~accessibilityViewIsModal: bool=?,
     ~accessible: bool=?,

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -11,7 +11,8 @@ let unchecked = false;
 [@bs.inline]
 let mixed = "mixed";
 
-[@bs.obj] external actionInfo: (~name: string, ~label: string=?) => actionInfo;
+[@bs.obj]
+external actionInfo: (~name: string, ~label: string=?, unit) => actionInfo;
 
 type actionEvent = AccessibilityActionEvent.t;
 

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -13,6 +13,8 @@ let mixed = "mixed";
 
 [@bs.obj] external actionInfo: (~name: string, ~label: string=?) => actionInfo;
 
+type actionEvent = AccessibilityActionEvent.t;
+
 [@bs.obj]
 external state:
   (

--- a/src/types/Accessibility.re
+++ b/src/types/Accessibility.re
@@ -31,13 +31,6 @@ type value;
 
 [@bs.obj] external intValue: (~min: int, ~max: int, ~now: int) => value;
 
-type componentType = [
-  | `none
-  | `button
-  | `radiobutton_checked
-  | `radiobutton_unchecked
-];
-
 type liveRegion = [ | `none | `polite | `assertive];
 
 type role = [
@@ -77,24 +70,4 @@ type role = [
   | `tablist
   | `timer
   | `toolbar
-];
-
-type trait = [
-  | `none
-  | `button
-  | `link
-  | `header
-  | `search
-  | `image
-  | `selected
-  | `plays
-  | `key
-  | `text
-  | `summary
-  | `disabled
-  | `frequentUpdates
-  | `startsMedia
-  | `adjustable
-  | `allowsDirectInteraction
-  | `pageTurn
 ];

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -11,7 +11,8 @@ let unchecked: checked(bool);
 [@bs.inline "mixed"]
 let mixed: checked(string);
 
-[@bs.obj] external actionInfo: (~name: string, ~label: string=?) => actionInfo;
+[@bs.obj]
+external actionInfo: (~name: string, ~label: string=?, unit) => actionInfo;
 
 type actionEvent = AccessibilityActionEvent.t;
 

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -13,6 +13,8 @@ let mixed: checked(string);
 
 [@bs.obj] external actionInfo: (~name: string, ~label: string=?) => actionInfo;
 
+type actionEvent = AccessibilityActionEvent.t;
+
 [@bs.obj]
 external state:
   (

--- a/src/types/Accessibility.rei
+++ b/src/types/Accessibility.rei
@@ -31,13 +31,6 @@ type value;
 
 [@bs.obj] external intValue: (~min: int, ~max: int, ~now: int) => value;
 
-type componentType = [
-  | `none
-  | `button
-  | `radiobutton_checked
-  | `radiobutton_unchecked
-];
-
 type liveRegion = [ | `none | `polite | `assertive];
 
 type role = [
@@ -77,24 +70,4 @@ type role = [
   | `tablist
   | `timer
   | `toolbar
-];
-
-type trait = [
-  | `none
-  | `button
-  | `link
-  | `header
-  | `search
-  | `image
-  | `selected
-  | `plays
-  | `key
-  | `text
-  | `summary
-  | `disabled
-  | `frequentUpdates
-  | `startsMedia
-  | `adjustable
-  | `allowsDirectInteraction
-  | `pageTurn
 ];

--- a/src/types/AccessibilityActionEvent.bs.js
+++ b/src/types/AccessibilityActionEvent.bs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Event$ReactNative = require("../apis/Event.bs.js");
+
+Event$ReactNative.SyntheticEvent({});
+
+/*  Not a pure module */

--- a/src/types/AccessibilityActionEvent.re
+++ b/src/types/AccessibilityActionEvent.re
@@ -1,0 +1,5 @@
+type payload = {actionName: string};
+
+include Event.SyntheticEvent({
+  type _payload = payload;
+});


### PR DESCRIPTION
This is the accessibility stuff from #705.

* Removed accessibilityComponentType and accessibilityTraits.
* Accessibility.role was actually already up to date (except for the value "switch" which we can't add because it's a keyword, unless we move this back to `@bs.string` which I would like to avoid).
* Accessibility.actionInfo was already there, but broken (missing `unit` to terminate argument list) => fixed.
* Added `AccessibilityActionEvent` and `onAccessibilityAction`.