### PR TITLE
Improve View.edgeInsets (add record for easier usage)

### DIFF
--- a/src/components/View.re
+++ b/src/components/View.re
@@ -1,6 +1,11 @@
 include NativeElement;
 
-type edgeInsets;
+type edgeInsets = {
+  left: float,
+  right: float,
+  bottom: float,
+  top: float,
+};
 [@bs.obj]
 external edgeInsets:
   (~left: float=?, ~right: float=?, ~top: float=?, ~bottom: float=?, unit) =>


### PR DESCRIPTION
I found usually specify all edgeInsets args like this

```reason
<TouchableOpacity
  onPress={(_) => ()}
  hitSlop={View.edgeInsets(
    ~top=20.,
    ~bottom=20.,
    ~left=20.,
    ~right=20.,
    (),
  )}
>
```

With this change, it should allow us to simplify specify a record directly

```reason
<TouchableOpacity
  onPress={(_) => ()}
  hitSlop={{
    top: 20.,
    bottom: 20.,
    left: 20.,
    right: 20.,
  }}
>
```

The function still works, but if you want to specify all args it's far easier imo (less characters).

Thoughts?