### PR TITLE
Pressable with child function and interaction states

### DIFF
--- a/src/components/Pressable.md
+++ b/src/components/Pressable.md
@@ -22,8 +22,15 @@ open ReactNative;
 
 [@react.component]
 let make = () => {
-    <Pressable onPress={_ => Js.log("Pressed")}>
-        <Text> "Press Me"->React.string </Text>
-    </Pressable>;
+  <Pressable
+    onPress={_ => Js.log("Pressed")}
+    style={({pressed}) =>
+      Style.(
+        style(~backgroundColor=pressed ? "rgb(210, 230, 255)" : "white", ())
+      )
+    }>
+    {({pressed}) =>
+        <Text> {pressed ? "Pressed!" : "Press Me"}->React.string </Text>}
+  </Pressable>;
 };
 ```

--- a/src/components/Pressable.md
+++ b/src/components/Pressable.md
@@ -19,7 +19,7 @@ You can read more about this [on the official Pressable documentation](https://r
 
 ## Example
 
-Current Pressable (deprecated)
+Current Pressable (deprecated because doesn't provide pressed state).
 
 ```reason
 open ReactNative;

--- a/src/components/Pressable.md
+++ b/src/components/Pressable.md
@@ -6,7 +6,7 @@ officialDoc: https://reactnative.dev/docs/pressable
 
 Pressable is a Core Component wrapper that can detect various stages of press interactions on any of it's defined children.
 
-⚠️ Current `Pressable` is deprecated, prefer `Pressable_` with the use of interactionState
+⚠️ Current `Pressable` is deprecated, prefer `Pressable_` that offers interaction states (eg: `pressed` state).
 
 ## How it works
 

--- a/src/components/Pressable.md
+++ b/src/components/Pressable.md
@@ -6,6 +6,8 @@ officialDoc: https://reactnative.dev/docs/pressable
 
 Pressable is a Core Component wrapper that can detect various stages of press interactions on any of it's defined children.
 
+⚠️ Current `Pressable` is deprecated, prefer `Pressable_` with the use of interactionState
+
 ## How it works
 
 On an element wrapped by `Pressable`:
@@ -17,12 +19,27 @@ You can read more about this [on the official Pressable documentation](https://r
 
 ## Example
 
+Current Pressable (deprecated)
+
 ```reason
 open ReactNative;
 
 [@react.component]
 let make = () => {
-  <Pressable
+    <Pressable onPress={_ => Js.log("Pressed")}>
+        <Text> "Press Me"->React.string </Text>
+    </Pressable>;
+};
+```
+
+Next Pressable (with interactionState)
+
+```reason
+open ReactNative;
+
+[@react.component]
+let make = () => {
+  <Pressable_
     onPress={_ => Js.log("Pressed")}
     style={({pressed}) =>
       Style.(
@@ -31,6 +48,6 @@ let make = () => {
     }>
     {({pressed}) =>
         <Text> {pressed ? "Pressed!" : "Press Me"}->React.string </Text>}
-  </Pressable>;
+  </Pressable_>;
 };
 ```

--- a/src/components/Pressable.re
+++ b/src/components/Pressable.re
@@ -47,7 +47,27 @@ external make:
     ~testID: string=?,
     ~android_disableSound: bool=?,
     ~android_ripple: rippleConfig=?,
-    ~testOnly_pressed: bool=?
+    ~testOnly_pressed: bool=?,
+    // React Native Web Props
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: Web.target=?
   ) =>
   React.element =
   "Pressable";

--- a/src/components/Pressable.re
+++ b/src/components/Pressable.re
@@ -7,6 +7,13 @@ external rippleConfig:
   (~color: Color.t=?, ~borderless: bool=?, ~radius: float=?, unit) =>
   rippleConfig;
 
+type interactionState = {
+  pressed: bool,
+  // React Native Web
+  hovered: option(bool),
+  focused: option(bool),
+};
+
 [@react.component] [@bs.module "react-native"]
 external make:
   (
@@ -33,7 +40,7 @@ external make:
                                 ]
                                   =?,
     // Pressable props
-    ~children: React.element=?,
+    ~children: interactionState => React.element=?,
     ~delayLongPress: int=?,
     ~disabled: bool=?,
     ~hitSlop: View.edgeInsets=?,
@@ -43,7 +50,7 @@ external make:
     ~onPress: Event.pressEvent => unit=?,
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
-    ~style: Style.t=?,
+    ~style: interactionState => Style.t=?,
     ~testID: string=?,
     ~android_disableSound: bool=?,
     ~android_ripple: rippleConfig=?,

--- a/src/components/Pressable.re
+++ b/src/components/Pressable.re
@@ -7,7 +7,7 @@ external rippleConfig:
   (~color: Color.t=?, ~borderless: bool=?, ~radius: float=?, unit) =>
   rippleConfig;
 
-[@deprecated "Please use Pressable_ instead"]
+[@deprecated "Please use `Pressable_` instead of `Pressable` to benefit of the full benefit of Pressable component (eg: pressed state in style props and children function). In next major release (0.64), `Pressable_` will become `Pressable`."]
 [@react.component]
 [@bs.module "react-native"]
 external make:

--- a/src/components/Pressable_.bs.js
+++ b/src/components/Pressable_.bs.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
+
+
+/* NativeElement-ReactNative Not a pure module */

--- a/src/components/Pressable_.re
+++ b/src/components/Pressable_.re
@@ -7,9 +7,14 @@ external rippleConfig:
   (~color: Color.t=?, ~borderless: bool=?, ~radius: float=?, unit) =>
   rippleConfig;
 
-[@deprecated "Please use Pressable_ instead"]
-[@react.component]
-[@bs.module "react-native"]
+type interactionState = {
+  pressed: bool,
+  // React Native Web
+  hovered: option(bool),
+  focused: option(bool),
+};
+
+[@react.component] [@bs.module "react-native"]
 external make:
   (
     ~ref: ref=?,
@@ -35,7 +40,7 @@ external make:
                                 ]
                                   =?,
     // Pressable props
-    ~children: React.element=?,
+    ~children: interactionState => React.element=?,
     ~delayLongPress: int=?,
     ~disabled: bool=?,
     ~hitSlop: View.edgeInsets=?,
@@ -45,11 +50,31 @@ external make:
     ~onPress: Event.pressEvent => unit=?,
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
-    ~style: Style.t=?,
+    ~style: interactionState => Style.t=?,
     ~testID: string=?,
     ~android_disableSound: bool=?,
     ~android_ripple: rippleConfig=?,
-    ~testOnly_pressed: bool=?
+    ~testOnly_pressed: bool=?,
+    // React Native Web Props
+    ~rel: [@bs.string] [
+            | `alternate
+            | `author
+            | [@bs.as "dns-prefetch"] `dnsPrefetch
+            | `icon
+            | `license
+            | `next
+            | `pingback
+            | `preconnect
+            | `prefetch
+            | `preload
+            | `prerender
+            | `prev
+            | `search
+            | `stylesheet
+          ]
+            =?,
+    ~href: string=?,
+    ~target: Web.target=?
   ) =>
   React.element =
   "Pressable";


### PR DESCRIPTION
Update `<Pressable>` binding with use of function with interactionState param for children and style props.

It's a breaking change with the current binding but I think it's better than having an `<PressableWithChildFunction>` or something like that.
Because the point of using Pressable component is to use those fine interaction states (`pressed` on react-native, with the addition of `hovered` and `focused` on react-native-web) for building a component.

If the developper don't want them he still can use Touchable components or simply
`<Pressable> {_ => <Text/> }</Pressable>`

`hovered` and `focused` are Option because they don't exist (yet?) in react-native, so if you want to create a component that work on both react-native and react-native-web envs, it's better to check values like this
`hoverd->Option.getWithDefault(false)`
But if you have a better idea to handle this, I would like to know it!