### PR TITLE
Fix type measure functions

### DIFF
--- a/src/elements/NativeMethods.re
+++ b/src/elements/NativeMethods.re
@@ -11,9 +11,25 @@ module Make = (T: {type t;}) => {
   [@bs.send] external blur: T.t => unit = "blur";
 
   [@bs.send]
-  external measure: (T.t, measureResult => unit) => unit = "measure";
+  external measure:
+    (
+      T.t,
+      (
+        ~x: float,
+        ~y: float,
+        ~width: float,
+        ~height: float,
+        ~pageX: float,
+        ~pageY: float
+      ) =>
+      unit
+    ) =>
+    unit =
+    "measure";
   [@bs.send]
-  external measureInWindow: (T.t, measureInWindowResult => unit) => unit =
+  external measureInWindow:
+    (T.t, (~x: float, ~y: float, ~width: float, ~height: float) => unit) =>
+    unit =
     "measureInWindow";
 
   [@bs.send]
@@ -21,8 +37,9 @@ module Make = (T: {type t;}) => {
     (
       T.t,
       ~relativeToNativeNode: nodeHandle,
-      ~onSuccess: measureResult => unit,
-      ~onFail: measureError => unit
+      ~onSuccess: (~left: float, ~top: float, ~width: float, ~height: float) =>
+                  unit,
+      ~onFail: unit => unit
     ) =>
     unit =
     "measureLayout";

--- a/src/types/NativeTypes.re
+++ b/src/types/NativeTypes.re
@@ -1,19 +1,1 @@
 type nodeHandle;
-
-type measureError;
-
-type measureResult = {
-  x: float,
-  y: float,
-  width: float,
-  height: float,
-  pageX: float,
-  pageY: float,
-};
-
-type measureInWindowResult = {
-  x: float,
-  y: float,
-  width: float,
-  height: float,
-};


### PR DESCRIPTION
Measure functions don't return object like it's now in the binding type.

react-native types : https://github.com/facebook/react-native/blob/master/Libraries/Renderer/shims/ReactNativeTypes.js

I typed callback function directly in the `NativeMethods` file because it's not a big file, so I think it's easier to find the informations we want about the typing of measure functions for someone browsing source files.

But if you prefer `type mesureCallback` & co in the `NativeTypes` file I can update the PR.

Thank's.