### PR TITLE
change android PlatformColor binding to use built-in selector

### DIFF
--- a/src/apis/PlatformColor.md
+++ b/src/apis/PlatformColor.md
@@ -34,6 +34,8 @@ See: [R.color](https://developer.android.com/reference/android/R.color)
 get: IOS.t => Color.t
 ```
 
+See: [UI Element Colors](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
+
 ### Android.getAttr
 
 `Android.getAttr` is used to get color information from android attributes.
@@ -41,6 +43,8 @@ get: IOS.t => Color.t
 ```reason
 getAttr: Android.t => Color.t
 ```
+
+See: [R.attr](https://developer.android.com/reference/android/R.attr)
 
 ### Android.getColor
 
@@ -50,12 +54,34 @@ getAttr: Android.t => Color.t
 getColor: Android.t => Color.t
 ```
 
+See: [R.color](https://developer.android.com/reference/android/R.color)
+
 ### Android.unsafeGet
 
 As some people use user-defined attrs for colors and this seems to be supported by React Native, this function is used for getting them using strings.
 
 ```reason
 unsafeGet: string => Color.t
+```
+
+### Android.get{n}
+
+Especially with Android, you may want to get multiple platform colors in case one is not supported by the system. In this case, you can use the `get{n}` function to retrieve the values. You can mix and match Android color and attributes in this call. The first value will be treated as default and rest will be treated as fallback.
+
+Defined up to 7 arguments.
+
+### Android.unsafeGet{n}
+
+The unsafe version of `get{n}` where a string can be passed in. This can be any Android resource query, for example: `?attr/colorPrimary` or `?android:attr/colorPrimary`, even resources defined within your Android app. The first value will be treated as default and rest will be treated as fallback.
+
+Defined up to 7 arguments.
+
+### Android.unsafeGetMultiple
+
+The array version of `unsafeGet{n}` supporting arbitrary number of fallbacks.
+
+```reason
+unsafeGetMultiple: array(string) => Color.t
 ```
 
 ## Example
@@ -70,7 +96,7 @@ let styles =
           ~color={
             switch (Platform.os) {
             | os when os == Platform.android =>
-              PlatformColor.Android.getColor(`primary_text_dark)
+              PlatformColor.Android.get2(`primary_text_dark, `colorPrimary)
             | os when os == Platform.ios => PlatformColor.IOS.get(`label)
             | _ => "black"
             };

--- a/src/apis/PlatformColor.re
+++ b/src/apis/PlatformColor.re
@@ -105,7 +105,6 @@ module Android = {
     (
     [@bs.string]
     [
-      | [@bs.as "?attr/color"] `color
       | [@bs.as "?android:attr/colorAccent"] `colorAccent
       | [@bs.as "?android:attr/colorActivatedHighlight"]
         `colorActivatedHighlight

--- a/src/apis/PlatformColor.re
+++ b/src/apis/PlatformColor.re
@@ -80,9 +80,11 @@ module Android = {
     [
       | [@bs.as "?attr/color"] `color
       | [@bs.as "?android:attr/colorAccent"] `colorAccent
-      | [@bs.as "?android:attr/colorActivatedHighlight"] `colorActivatedHighlight
+      | [@bs.as "?android:attr/colorActivatedHighlight"]
+        `colorActivatedHighlight
       | [@bs.as "?android:attr/colorBackground"] `colorBackground
-      | [@bs.as "?android:attr/colorBackgroundFloating"] `colorBackgroundFloating
+      | [@bs.as "?android:attr/colorBackgroundFloating"]
+        `colorBackgroundFloating
       | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
       | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
       | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
@@ -91,8 +93,10 @@ module Android = {
       | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
       | [@bs.as "?android:attr/colorForeground"] `colorForeground
       | [@bs.as "?android:attr/colorForegroundInverse"] `colorForegroundInverse
-      | [@bs.as "?android:attr/colorLongPressedHighlight"] `colorLongPressedHighlight
-      | [@bs.as "?android:attr/colorMultiSelectHighlight"] `colorMultiSelectHighlight
+      | [@bs.as "?android:attr/colorLongPressedHighlight"]
+        `colorLongPressedHighlight
+      | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+        `colorMultiSelectHighlight
       | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
       | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
       | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
@@ -101,4 +105,1611 @@ module Android = {
     ) =>
     Color.t =
     "PlatformColor";
+
+  [@bs.module "react-native"]
+  external get2:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external get3:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external get4:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external get5:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external get6:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+  [@bs.module "react-native"]
+  external get7:
+    (
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ],
+      [@bs.string] [
+        | [@bs.as "@android:color/background_dark"] `background_dark
+        | [@bs.as "@android:color/background_light"] `background_light
+        | [@bs.as "@android:color/black"] `black
+        | [@bs.as "@android:color/darker_gray"] `darker_gray
+        | [@bs.as "@android:color/holo_blue_bright"] `holo_blue_bright
+        | [@bs.as "@android:color/holo_blue_dark"] `holo_blue_dark
+        | [@bs.as "@android:color/holo_blue_light"] `holo_blue_light
+        | [@bs.as "@android:color/holo_green_dark"] `holo_green_dark
+        | [@bs.as "@android:color/holo_green_light"] `holo_green_light
+        | [@bs.as "@android:color/holo_orange_dark"] `holo_orange_dark
+        | [@bs.as "@android:color/holo_orange_light"] `holo_orange_light
+        | [@bs.as "@android:color/holo_purple"] `holo_purple
+        | [@bs.as "@android:color/holo_red_dark"] `holo_red_dark
+        | [@bs.as "@android:color/holo_red_light"] `holo_red_light
+        | [@bs.as "@android:color/primary_text_dark"] `primary_text_dark
+        | [@bs.as "@android:color/primary_text_dark_nodisable"]
+          `primary_text_dark_nodisable
+        | [@bs.as "@android:color/primary_text_light"] `primary_text_light
+        | [@bs.as "@android:color/primary_text_light_nodisable"]
+          `primary_text_light_nodisable
+        | [@bs.as "@android:color/secondary_text_dark"] `secondary_text_dark
+        | [@bs.as "@android:color/secondary_text_dark_nodisable"]
+          `secondary_text_dark_nodisable
+        | [@bs.as "@android:color/secondary_text_light"] `secondary_text_light
+        | [@bs.as "@android:color/secondary_text_light_nodisable"]
+          `secondary_text_light_nodisable
+        | [@bs.as "@android:color/tab_indicator_text"] `tab_indicator_text
+        | [@bs.as "@android:color/tertiary_text_dark"] `tertiary_text_dark
+        | [@bs.as "@android:color/tertiary_text_light"] `tertiary_text_light
+        | [@bs.as "@android:color/transparent"] `transparent
+        | [@bs.as "@android:color/white"] `white
+        | [@bs.as "@android:color/widget_edittext_dark"] `widget_edittext_dark
+        | [@bs.as "?android:attr/colorAccent"] `colorAccent
+        | [@bs.as "?android:attr/colorActivatedHighlight"]
+          `colorActivatedHighlight
+        | [@bs.as "?android:attr/colorBackground"] `colorBackground
+        | [@bs.as "?android:attr/colorBackgroundFloating"]
+          `colorBackgroundFloating
+        | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+        | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+        | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+        | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+        | [@bs.as "?android:attr/colorError"] `colorError
+        | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+        | [@bs.as "?android:attr/colorForeground"] `colorForeground
+        | [@bs.as "?android:attr/colorForegroundInverse"]
+          `colorForegroundInverse
+        | [@bs.as "?android:attr/colorLongPressedHighlight"]
+          `colorLongPressedHighlight
+        | [@bs.as "?android:attr/colorMultiSelectHighlight"]
+          `colorMultiSelectHighlight
+        | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+        | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+        | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+        | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
+      ]
+    ) =>
+    Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet2: (string, string) => Color.t = "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet3: (string, string, string) => Color.t = "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet4: (string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet5: (string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet6:
+    (string, string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet7:
+    (string, string, string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"] [@bs.variadic]
+  external unsafeGetMultiple: array(string) => Color.t = "PlatformColor";
 };

--- a/src/apis/PlatformColor.re
+++ b/src/apis/PlatformColor.re
@@ -79,24 +79,24 @@ module Android = {
     [@bs.string]
     [
       | [@bs.as "?attr/color"] `color
-      | [@bs.as "?attr/colorAccent"] `colorAccent
-      | [@bs.as "?attr/colorActivatedHighlight"] `colorActivatedHighlight
-      | [@bs.as "?attr/colorBackground"] `colorBackground
-      | [@bs.as "?attr/colorBackgroundFloating"] `colorBackgroundFloating
-      | [@bs.as "?attr/colorButtonNormal"] `colorButtonNormal
-      | [@bs.as "?attr/colorControlHighlight"] `colorControlHighlight
-      | [@bs.as "?attr/colorControlNormal"] `colorControlNormal
-      | [@bs.as "?attr/colorEdgeEffect"] `colorEdgeEffect
-      | [@bs.as "?attr/colorError"] `colorError
-      | [@bs.as "?attr/colorFocusedHighlight"] `colorFocusedHighlight
-      | [@bs.as "?attr/colorForeground"] `colorForeground
-      | [@bs.as "?attr/colorForegroundInverse"] `colorForegroundInverse
-      | [@bs.as "?attr/colorLongPressedHighlight"] `colorLongPressedHighlight
-      | [@bs.as "?attr/colorMultiSelectHighlight"] `colorMultiSelectHighlight
-      | [@bs.as "?attr/colorPressedHighlight"] `colorPressedHighlight
-      | [@bs.as "?attr/colorPrimary"] `colorPrimary
-      | [@bs.as "?attr/colorPrimaryDark"] `colorPrimaryDark
-      | [@bs.as "?attr/colorSecondary"] `colorSecondary
+      | [@bs.as "?android:attr/colorAccent"] `colorAccent
+      | [@bs.as "?android:attr/colorActivatedHighlight"] `colorActivatedHighlight
+      | [@bs.as "?android:attr/colorBackground"] `colorBackground
+      | [@bs.as "?android:attr/colorBackgroundFloating"] `colorBackgroundFloating
+      | [@bs.as "?android:attr/colorButtonNormal"] `colorButtonNormal
+      | [@bs.as "?android:attr/colorControlHighlight"] `colorControlHighlight
+      | [@bs.as "?android:attr/colorControlNormal"] `colorControlNormal
+      | [@bs.as "?android:attr/colorEdgeEffect"] `colorEdgeEffect
+      | [@bs.as "?android:attr/colorError"] `colorError
+      | [@bs.as "?android:attr/colorFocusedHighlight"] `colorFocusedHighlight
+      | [@bs.as "?android:attr/colorForeground"] `colorForeground
+      | [@bs.as "?android:attr/colorForegroundInverse"] `colorForegroundInverse
+      | [@bs.as "?android:attr/colorLongPressedHighlight"] `colorLongPressedHighlight
+      | [@bs.as "?android:attr/colorMultiSelectHighlight"] `colorMultiSelectHighlight
+      | [@bs.as "?android:attr/colorPressedHighlight"] `colorPressedHighlight
+      | [@bs.as "?android:attr/colorPrimary"] `colorPrimary
+      | [@bs.as "?android:attr/colorPrimaryDark"] `colorPrimaryDark
+      | [@bs.as "?android:attr/colorSecondary"] `colorSecondary
     ]
     ) =>
     Color.t =

--- a/src/apis/PlatformColor.re
+++ b/src/apis/PlatformColor.re
@@ -32,6 +32,33 @@ module Android = {
   external unsafeGet: string => Color.t = "PlatformColor";
 
   [@bs.module "react-native"]
+  external unsafeGet2: (string, string) => Color.t = "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet3: (string, string, string) => Color.t = "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet4: (string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet5: (string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet6:
+    (string, string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"]
+  external unsafeGet7:
+    (string, string, string, string, string, string, string) => Color.t =
+    "PlatformColor";
+
+  [@bs.module "react-native"] [@bs.variadic]
+  external unsafeGetMultiple: array(string) => Color.t = "PlatformColor";
+
+  [@bs.module "react-native"]
   external getColor:
     (
     [@bs.string]
@@ -1685,31 +1712,4 @@ module Android = {
     ) =>
     Color.t =
     "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet2: (string, string) => Color.t = "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet3: (string, string, string) => Color.t = "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet4: (string, string, string, string) => Color.t =
-    "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet5: (string, string, string, string, string) => Color.t =
-    "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet6:
-    (string, string, string, string, string, string) => Color.t =
-    "PlatformColor";
-
-  [@bs.module "react-native"]
-  external unsafeGet7:
-    (string, string, string, string, string, string, string) => Color.t =
-    "PlatformColor";
-
-  [@bs.module "react-native"] [@bs.variadic]
-  external unsafeGetMultiple: array(string) => Color.t = "PlatformColor";
 };


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Hi there,

A quick PR for the default Android PlatformColor selectors to get the system-defined values instead of app-defined values. In the default react native init app, there's no colors defined in `styles.xml`, so the app would get the following error when rendering using PlatformColor

```
2021-03-07 18:04:42.833 9614-9614/com.precisely E/unknown:ReactNative: Exception in native call
    com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating property 'backgroundColor' of a view managed by: RCTView
        at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:102)
        at com.facebook.react.uimanager.ViewManagerPropertyUpdater$FallbackViewManagerSetter.setProperty(ViewManagerPropertyUpdater.java:136)
        at com.facebook.react.uimanager.ViewManagerPropertyUpdater.updateProps(ViewManagerPropertyUpdater.java:56)
        at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:49)
        at com.facebook.react.uimanager.NativeViewHierarchyManager.createView(NativeViewHierarchyManager.java:270)
        at com.facebook.react.uimanager.UIViewOperationQueue$CreateViewOperation.execute(UIViewOperationQueue.java:186)
        ...
     Caused by: com.facebook.react.bridge.JSApplicationCausedNativeException: ColorValue: None of the paths in the `resource_paths` array resolved to a color resource.
        at com.facebook.react.bridge.ColorPropConverter.getColor(ColorPropConverter.java:71)
        at com.facebook.react.uimanager.ViewManagersPropertyCache$ColorPropSetter.getValueOrDefault(ViewManagersPropertyCache.java:213)
       ...
```

The colors is rendered as follows (on Pixel 2 XL, Android 11, using default `Theme.AppCompat.DayNight.NoActionBar`):

1. Dark Theme
![Pixel2XL_dark](https://user-images.githubusercontent.com/8755833/110236351-3c51f180-7f70-11eb-8b4d-4f269b2e00a7.png)
1. Light Theme
![Pixel2XL_light](https://user-images.githubusercontent.com/8755833/110236353-3d831e80-7f70-11eb-8cae-5bd6e984a15f.png)

I've left `color` as it is since both `?attr/color` and `?android:attr/color` generated the above error.

My only concern here is that this is a change in behaviour for anyone already using these variants to get values from application style, since they'll need to use `unsafeGet` to get the same behaviour.

